### PR TITLE
Enhance Preferences UI tap area and bump version to 0.9.5

### DIFF
--- a/Warden.xcodeproj/project.pbxproj
+++ b/Warden.xcodeproj/project.pbxproj
@@ -1237,7 +1237,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.9.4;
+				CURRENT_PROJECT_VERSION = 0.9.5;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8S4248F6RV;
 				ENABLE_APP_SANDBOX = NO;
@@ -1263,7 +1263,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.9.4;
+				MARKETING_VERSION = 0.9.5;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = karatsidhu.WardenAI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1287,7 +1287,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0.9.4;
+				CURRENT_PROJECT_VERSION = 0.9.5;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8S4248F6RV;
 				ENABLE_APP_SANDBOX = NO;
@@ -1313,7 +1313,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.9.4;
+				MARKETING_VERSION = 0.9.5;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = karatsidhu.WardenAI;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Warden/UI/Preferences/PreferencesView.swift
+++ b/Warden/UI/Preferences/PreferencesView.swift
@@ -45,6 +45,7 @@ struct TopTabItem: View {
                     .lineLimit(1)
             }
             .frame(width: 76, height: 48)
+            .contentShape(Rectangle())
             .foregroundStyle(isSelected ? .primary : .secondary)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)


### PR DESCRIPTION
## Summary
- **UI Enhancement**: Modified `PreferencesView.swift` to make the entire tab area (icon + text) clickable in the Preferences view, not just the content itself. This improves usability.
- **Version Bump**: Incremented the project version to 0.9.5 in `Warden.xcodeproj/project.pbxproj`.

## Test plan
- Build and run the app.
- Open Preferences.
- Click anywhere within the bounds of a tab item (e.g., General, Appearance). Verify that the tab selection changes even if not clicking directly on the icon or text.
- Verify the version number in the project settings or About window (if applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.9.5

* **Bug Fixes**
  * Improved the clickable area of preference tab buttons for better usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->