### PR TITLE
Remove chat button labels

### DIFF
--- a/Warden/UI/Chat/BottomContainer/MessageInputView.swift
+++ b/Warden/UI/Chat/BottomContainer/MessageInputView.swift
@@ -32,7 +32,7 @@ struct MessageInputView: View {
     var onAddFile: () -> Void
     var onAddAssistant: (() -> Void)?
     var onStopStreaming: (() -> Void)?
-    var inputPlaceholderText: String = "Enter a message here, press ⏎ to send"
+    var inputPlaceholderText: String = "Ask Anything"
     var cornerRadius: Double = 18.0
     
     @StateObject private var mcpManager = MCPManager.shared
@@ -107,31 +107,7 @@ struct MessageInputView: View {
                             .help("Web Search")
                             .accessibilityLabel("Web Search")
                         }
-                        
-                        // Rephrase (Text tool icon)
-                        if showsRephraseButton {
-                            Button(action: rephraseText) {
-                                ZStack {
-                                    if rephraseService.isRephrasing {
-                                        ProgressView()
-                                            .scaleEffect(0.5)
-                                            .frame(width: 14, height: 14)
-                                    } else {
-                                        Image(systemName: "wand.and.stars")
-                                            .font(.system(size: 12))
-                                            .foregroundColor(rephraseService.isRephrasing ? .white : .secondary)
-                                    }
-                                }
-                                .frame(width: 24, height: 24)
-                                .background(rephraseService.isRephrasing ? Color.accentColor : Color.clear)
-                                .cornerRadius(6)
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                            .help("Rephrase Message")
-                            .accessibilityLabel("Rephrase Message")
-                            .disabled(!canRephrase)
-                        }
-                        
+
                         // Multi-Agent Mode
                         if enableMultiAgentMode {
                             HStack(spacing: 8) {
@@ -235,7 +211,19 @@ struct MessageInputView: View {
             Button(action: onAddFile) {
                 Label("Add File", systemImage: "doc")
             }
-            
+
+            if showsRephraseButton {
+                Divider()
+                Button(action: rephraseText) {
+                    if rephraseService.isRephrasing {
+                        Label("Rephrasing...", systemImage: "wand.and.stars")
+                    } else {
+                        Label("Rephrase", systemImage: "wand.and.stars")
+                    }
+                }
+                .disabled(!canRephrase || rephraseService.isRephrasing)
+            }
+
             if showsMCPTools {
                 Divider()
                 

--- a/Warden/UI/Chat/BubbleView/ChatBubbleView.swift
+++ b/Warden/UI/Chat/BubbleView/ChatBubbleView.swift
@@ -248,19 +248,19 @@ struct ChatBubbleView: View {
             }
 
             if content.systemMessage {
-                ToolbarButton(icon: "pencil", text: "Edit") {
+                ToolbarButton(icon: "pencil", text: "") {
                     onEdit?()
                 }
             }
-            
+
             if content.own && !content.systemMessage, message != nil {
-                ToolbarButton(icon: "pencil", text: "Edit") {
+                ToolbarButton(icon: "pencil", text: "") {
                     onEdit?()
                 }
             }
 
             if content.isLatestMessage && !content.systemMessage {
-                ToolbarButton(icon: "arrow.clockwise", text: "Retry") {
+                ToolbarButton(icon: "arrow.clockwise", text: "") {
                     NotificationCenter.default.post(name: .retryMessage, object: nil)
                 }
             }
@@ -270,7 +270,7 @@ struct ChatBubbleView: View {
                 BranchToolbarButton(message: msg)
             }
 
-            ToolbarButton(icon: isCopied ? "checkmark" : "doc.on.doc", text: "Copy") {
+            ToolbarButton(icon: isCopied ? "checkmark" : "doc.on.doc", text: "") {
                 copyMessageToClipboard(content.message)
             }
 
@@ -623,13 +623,8 @@ struct BranchToolbarButton: View {
         Button(action: {
             showPopover = true
         }) {
-            HStack(spacing: 4) {
-                Image(systemName: "arrow.triangle.branch")
-                    .font(.system(size: 10, weight: .medium))
-                
-                Text("Branch")
-                    .font(.system(size: 11, weight: .medium))
-            }
+            Image(systemName: "arrow.triangle.branch")
+                .font(.system(size: 10, weight: .medium))
             .padding(.horizontal, 8)
             .padding(.vertical, 6)
             .background(

--- a/Warden/UI/Chat/CenteredInputView.swift
+++ b/Warden/UI/Chat/CenteredInputView.swift
@@ -38,18 +38,6 @@ struct CenteredInputView: View {
                     Spacer()
                     
                     VStack(spacing: 40) {
-                        // Greeting Header
-                        VStack(spacing: 8) {
-                            Text("What can I help you with?")
-                                .font(.system(size: 28, weight: .medium))
-                                .foregroundStyle(.primary)
-                            
-                            Text("Ask questions, generate code, or get creative ideas")
-                                .font(.system(size: 13))
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(.bottom, 20)
-                        
                         // Input Section
                         VStack(spacing: 24) {
                             // Enhanced Input Container
@@ -66,7 +54,7 @@ struct CenteredInputView: View {
                                     onAddFile: onAddFile,
                                     onAddAssistant: onAddAssistant,
                                     onStopStreaming: onStopStreaming,
-                                    inputPlaceholderText: "Enter a message here, press ⏎ to send",
+                                    inputPlaceholderText: "Ask Anything",
                                     cornerRadius: 18.0
                                 )
                                 .frame(maxWidth: 1000)

--- a/Warden/UI/Chat/QuickChatView.swift
+++ b/Warden/UI/Chat/QuickChatView.swift
@@ -55,7 +55,7 @@ struct QuickChatView: View {
                 onAddImage: selectAndAddImages,
                 onAddFile: selectAndAddFiles,
                 onStopStreaming: stopCurrentStream,
-                inputPlaceholderText: "Ask anything...",
+                inputPlaceholderText: "Ask Anything",
                 cornerRadius: 20.0
             )
             .padding(.horizontal, 16)

--- a/Warden/UI/ChatList/ChatListView.swift
+++ b/Warden/UI/ChatList/ChatListView.swift
@@ -244,11 +244,11 @@ struct ChatListView: View {
                     .foregroundColor(.gray)
             }
 
-            TextField("Search chats", text: $searchText)
+            TextField("Search", text: $searchText)
                 .textFieldStyle(PlainTextFieldStyle())
                 .font(.system(.body))
                 .focused($isSearchFocused)
-                .accessibilityLabel("Search chats")
+                .accessibilityLabel("Search")
                 .onExitCommand {
                     searchText = ""
                     isSearchFocused = false


### PR DESCRIPTION
## 🔄 Pull Request

### 📝 Description
- Removes text labels from in-bubble action buttons (Edit/Retry/Copy/Branch) for a cleaner UI.
- Moves Rephrase out of the inline composer toolbar into the composer context menu.
- Updates placeholder copy to “Ask Anything” and chat search to “Search”.

### 🎯 Type of Change
- [x] 🎨 Style/UI improvement

### 🔗 Related Issues

### 🧪 Testing
- [ ] I have tested this change locally

**Test Details:**
Unable to run `xcodebuild` in this environment (only CommandLineTools active).

### ✅ Checklist
- [x] My code follows the existing code style and patterns
- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated message input placeholder text to "Ask Anything" across chat interfaces
  * Removed greeting header from initial input view for a cleaner interface
  * Relocated rephrase button from top toolbar to attachments area with updated visual styling
  * Converted toolbar action buttons (Edit, Retry, Copy, Branch) to icon-only display
  * Simplified search bar placeholder text from "Search chats" to "Search"

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->