### PR TITLE
Add Prompt Library and Usage & Cost tracking

### DIFF
--- a/Warden.xcodeproj/project.pbxproj
+++ b/Warden.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		066C487A4C4D90158727285C /* UsageTrackingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6F0B7C0F3CD12F0C219424 /* UsageTrackingService.swift */; }
+		9E90CAF7EB7832BE1278D6CE /* PromptLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A795AF4334DC0A0A24A65315 /* PromptLibraryManager.swift */; }
+		6578702A99D87DCFE85988AD /* PromptCompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505468F06FE848C40DB1C44D /* PromptCompletionView.swift */; }
+		15A13334CD61C6A012339A24 /* TabPromptLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CAE40899A1CDCA21BC23F4 /* TabPromptLibraryView.swift */; }
+		A888979D6D89F6230989A1BA /* TabUsageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2537625D8F98A96D866BC6 /* TabUsageView.swift */; }
 		1944D194B23F4B968C99D50A /* MCPAgentSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFEA1423CE44C558E44763C /* MCPAgentSelector.swift */; };
 		4A0BCBBC2D5199140033AB96 /* ButtonWithStatusIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0BCBBB2D5199140033AB96 /* ButtonWithStatusIndicator.swift */; };
 		4A0E02852D0F571000D2FAF3 /* PerplexityHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E02842D0F571000D2FAF3 /* PerplexityHandler.swift */; };
@@ -220,6 +225,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4F6F0B7C0F3CD12F0C219424 /* UsageTrackingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageTrackingService.swift; sourceTree = "<group>" };
+		A795AF4334DC0A0A24A65315 /* PromptLibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptLibraryManager.swift; sourceTree = "<group>" };
+		505468F06FE848C40DB1C44D /* PromptCompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCompletionView.swift; sourceTree = "<group>" };
+		A5CAE40899A1CDCA21BC23F4 /* TabPromptLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPromptLibraryView.swift; sourceTree = "<group>" };
+		8A2537625D8F98A96D866BC6 /* TabUsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabUsageView.swift; sourceTree = "<group>" };
 		09C5F31F2F664B9BBD13C0CC /* ChatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatService.swift; sourceTree = "<group>"; };
 		1E14DF97A8974C028719A178 /* MCPSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPSettingsView.swift; sourceTree = "<group>"; };
 		442D774F210E4BC89CB19BDF /* AddMCPAgentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMCPAgentSheet.swift; sourceTree = "<group>"; };
@@ -512,6 +522,7 @@
 				4A0BCBBB2D5199140033AB96 /* ButtonWithStatusIndicator.swift */,
 				4ABB86782CFBDBD3004EC7B1 /* HighlightedText.swift */,
 				4A194C052C9633BC003C8782 /* EntityListView.swift */,
+				505468F06FE848C40DB1C44D /* PromptCompletionView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -567,6 +578,8 @@
 				C49FCBE52ECC2535003B51AF /* TabContributionsView.swift */,
 				4AFDEB7D2AFF90FB00BA8642 /* TabDangerZoneView.swift */,
 				4A315DB12C8CD8410095ABD1 /* TabAIPersonasView.swift */,
+				A5CAE40899A1CDCA21BC23F4 /* TabPromptLibraryView.swift */,
+				8A2537625D8F98A96D866BC6 /* TabUsageView.swift */,
 			);
 			path = Preferences;
 			sourceTree = "<group>";
@@ -685,6 +698,8 @@
 				4AA6EF5C2C566009003B6D41 /* MessageManager.swift */,
 				7F0000012E00000100000001 /* GlobalHotkeyHandler.swift */,
 				7F0000022E00000100000001 /* FloatingPanelManager.swift */,
+				4F6F0B7C0F3CD12F0C219424 /* UsageTrackingService.swift */,
+				A795AF4334DC0A0A24A65315 /* PromptLibraryManager.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -972,6 +987,11 @@
 		4A399C9129BC8FEF00E98796 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
+				066C487A4C4D90158727285C /* UsageTrackingService.swift in Sources */,
+				9E90CAF7EB7832BE1278D6CE /* PromptLibraryManager.swift in Sources */,
+				6578702A99D87DCFE85988AD /* PromptCompletionView.swift in Sources */,
+				15A13334CD61C6A012339A24 /* TabPromptLibraryView.swift in Sources */,
+				A888979D6D89F6230989A1BA /* TabUsageView.swift in Sources */,
 				C43A76382ED5672E006DA5E2 /* SearchResultsPreviewView.swift in Sources */,
 				C43A76392ED5672E006DA5E2 /* ToolCallProgressView.swift in Sources */,
 				C4FF23882EED7A4100C17D8B /* StreamingAttributedTextView.swift in Sources */,

--- a/Warden.xcodeproj/project.pbxproj
+++ b/Warden.xcodeproj/project.pbxproj
@@ -225,11 +225,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		4F6F0B7C0F3CD12F0C219424 /* UsageTrackingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageTrackingService.swift; sourceTree = "<group>" };
-		A795AF4334DC0A0A24A65315 /* PromptLibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptLibraryManager.swift; sourceTree = "<group>" };
-		505468F06FE848C40DB1C44D /* PromptCompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCompletionView.swift; sourceTree = "<group>" };
-		A5CAE40899A1CDCA21BC23F4 /* TabPromptLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPromptLibraryView.swift; sourceTree = "<group>" };
-		8A2537625D8F98A96D866BC6 /* TabUsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabUsageView.swift; sourceTree = "<group>" };
+		4F6F0B7C0F3CD12F0C219424 /* UsageTrackingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageTrackingService.swift; sourceTree = "<group>"; };
+		A795AF4334DC0A0A24A65315 /* PromptLibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptLibraryManager.swift; sourceTree = "<group>"; };
+		505468F06FE848C40DB1C44D /* PromptCompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCompletionView.swift; sourceTree = "<group>"; };
+		A5CAE40899A1CDCA21BC23F4 /* TabPromptLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPromptLibraryView.swift; sourceTree = "<group>"; };
+		8A2537625D8F98A96D866BC6 /* TabUsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabUsageView.swift; sourceTree = "<group>"; };
 		09C5F31F2F664B9BBD13C0CC /* ChatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatService.swift; sourceTree = "<group>"; };
 		1E14DF97A8974C028719A178 /* MCPSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPSettingsView.swift; sourceTree = "<group>"; };
 		442D774F210E4BC89CB19BDF /* AddMCPAgentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMCPAgentSheet.swift; sourceTree = "<group>"; };

--- a/Warden.xcodeproj/project.pbxproj
+++ b/Warden.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		066C487A4C4D90158727285C /* UsageTrackingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6F0B7C0F3CD12F0C219424 /* UsageTrackingService.swift */; }
-		9E90CAF7EB7832BE1278D6CE /* PromptLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A795AF4334DC0A0A24A65315 /* PromptLibraryManager.swift */; }
-		6578702A99D87DCFE85988AD /* PromptCompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505468F06FE848C40DB1C44D /* PromptCompletionView.swift */; }
-		15A13334CD61C6A012339A24 /* TabPromptLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CAE40899A1CDCA21BC23F4 /* TabPromptLibraryView.swift */; }
-		A888979D6D89F6230989A1BA /* TabUsageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2537625D8F98A96D866BC6 /* TabUsageView.swift */; }
+		066C487A4C4D90158727285C /* UsageTrackingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6F0B7C0F3CD12F0C219424 /* UsageTrackingService.swift */; };
+		9E90CAF7EB7832BE1278D6CE /* PromptLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A795AF4334DC0A0A24A65315 /* PromptLibraryManager.swift */; };
+		6578702A99D87DCFE85988AD /* PromptCompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505468F06FE848C40DB1C44D /* PromptCompletionView.swift */; };
+		15A13334CD61C6A012339A24 /* TabPromptLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CAE40899A1CDCA21BC23F4 /* TabPromptLibraryView.swift */; };
+		A888979D6D89F6230989A1BA /* TabUsageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2537625D8F98A96D866BC6 /* TabUsageView.swift */; };
 		1944D194B23F4B968C99D50A /* MCPAgentSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFEA1423CE44C558E44763C /* MCPAgentSelector.swift */; };
 		4A0BCBBC2D5199140033AB96 /* ButtonWithStatusIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0BCBBB2D5199140033AB96 /* ButtonWithStatusIndicator.swift */; };
 		4A0E02852D0F571000D2FAF3 /* PerplexityHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E02842D0F571000D2FAF3 /* PerplexityHandler.swift */; };

--- a/Warden/Models/Models.swift
+++ b/Warden/Models/Models.swift
@@ -372,3 +372,67 @@ extension APIServiceEntity: NSCopying {
         return copy
     }
 }
+
+// MARK: - Prompt Library
+
+public class PromptEntity: NSManagedObject, Identifiable {
+    @NSManaged public var id: UUID
+    @NSManaged public var name: String?
+    @NSManaged public var content: String?
+    @NSManaged public var shortcut: String?
+    @NSManaged public var category: String?
+    @NSManaged public var usageCount: Int64
+    @NSManaged public var createdDate: Date?
+    @NSManaged public var lastUsedDate: Date?
+
+    /// Slash-command trigger, e.g. "/explain". Falls back to the lowercased name.
+    public var commandTrigger: String {
+        if let shortcut = shortcut?.trimmingCharacters(in: .whitespacesAndNewlines), !shortcut.isEmpty {
+            return shortcut.hasPrefix("/") ? shortcut : "/" + shortcut
+        }
+        let trimmedName = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedName.isEmpty ? "" : "/" + trimmedName.lowercased()
+    }
+
+    /// Replaces {{text}} placeholders with the provided selection (kept as-is when no selection).
+    public func resolvedContent(selection: String?) -> String? {
+        guard var resolved = content else { return nil }
+        if let selection = selection, !selection.isEmpty {
+            resolved = resolved
+                .replacingOccurrences(of: "{{text}}", with: selection)
+                .replacingOccurrences(of: "{{selection}}", with: selection)
+        }
+        return resolved
+    }
+
+    public static func fetchRequest(sortedByUsage: Bool = false) -> NSFetchRequest<PromptEntity> {
+        let request = NSFetchRequest<PromptEntity>(entityName: "PromptEntity")
+        request.sortDescriptors = [
+            NSSortDescriptor(
+                key: sortedByUsage ? "usageCount" : "name",
+                ascending: !sortedByUsage
+            )
+        ]
+        return request
+    }
+}
+
+// MARK: - Usage Tracking
+
+public class UsageRecordEntity: NSManagedObject, Identifiable {
+    @NSManaged public var id: UUID
+    @NSManaged public var date: Date?
+    @NSManaged public var providerName: String?
+    @NSManaged public var modelId: String?
+    @NSManaged public var chatID: UUID?
+    @NSManaged public var inputTokens: Int64
+    @NSManaged public var outputTokens: Int64
+    @NSManaged public var cachedInputTokens: Int64
+    @NSManaged public var reasoningTokens: Int64
+    @NSManaged public var estimatedCostUSD: Double
+    @NSManaged public var pricingSource: String?
+
+    public static func fetchRequest() -> NSFetchRequest<UsageRecordEntity> {
+        NSFetchRequest<UsageRecordEntity>(entityName: "UsageRecordEntity")
+    }
+}

--- a/Warden/Store/wardenDataModel.xcdatamodeld/wardenDataModel 1.xcdatamodel/contents
+++ b/Warden/Store/wardenDataModel.xcdatamodeld/wardenDataModel 1.xcdatamodel/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="APIServiceEntity" representedClassName="APIServiceEntity" syncable="YES" codeGenerationType="class">
+    <entity name="APIServiceEntity" representedClassName="APIServiceEntity" syncable="YES">
         <attribute name="addedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="contextSize" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="defaultAgent" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -46,7 +46,7 @@
         <relationship name="persona" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PersonaEntity"/>
         <relationship name="project" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProjectEntity" inverseName="chats" inverseEntity="ProjectEntity"/>
     </entity>
-    <entity name="FileEntity" representedClassName="FileEntity" syncable="YES" codeGenerationType="class">
+    <entity name="FileEntity" representedClassName="FileEntity" syncable="YES">
         <attribute name="blobID" optional="YES" attributeType="String"/>
         <attribute name="fileName" optional="YES" attributeType="String"/>
         <attribute name="fileSize" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -56,7 +56,7 @@
         <attribute name="textContent" optional="YES" attributeType="String"/>
         <attribute name="thumbnailData" optional="YES" attributeType="Binary"/>
     </entity>
-    <entity name="ImageEntity" representedClassName="ImageEntity" syncable="YES" codeGenerationType="class">
+    <entity name="ImageEntity" representedClassName="ImageEntity" syncable="YES">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="image" attributeType="Binary"/>
         <attribute name="imageFormat" optional="YES" attributeType="String" defaultValueString="jpeg"/>
@@ -78,7 +78,7 @@
         <attribute name="waitingForResponse" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChatEntity" inverseName="messages" inverseEntity="ChatEntity"/>
     </entity>
-    <entity name="PersonaEntity" representedClassName="PersonaEntity" syncable="YES" codeGenerationType="class">
+    <entity name="PersonaEntity" representedClassName="PersonaEntity" syncable="YES">
         <attribute name="addedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="color" optional="YES" attributeType="String"/>
         <attribute name="editedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -89,7 +89,7 @@
         <attribute name="temperature" optional="YES" attributeType="Float" minValueString="0" maxValueString="1" defaultValueString="0.7" usesScalarValueType="YES"/>
         <relationship name="defaultApiService" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APIServiceEntity"/>
     </entity>
-    <entity name="ProjectEntity" representedClassName="ProjectEntity" syncable="YES" codeGenerationType="class">
+    <entity name="ProjectEntity" representedClassName="ProjectEntity" syncable="YES">
         <attribute name="aiGeneratedSummary" optional="YES" attributeType="String"/>
         <attribute name="colorCode" optional="YES" attributeType="String" defaultValueString="#007AFF"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>

--- a/Warden/Store/wardenDataModel.xcdatamodeld/wardenDataModel 1.xcdatamodel/contents
+++ b/Warden/Store/wardenDataModel.xcdatamodeld/wardenDataModel 1.xcdatamodel/contents
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25A362" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="APIServiceEntity" representedClassName="APIServiceEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="addedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="contextSize" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="defaultAgent" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="editedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="generateChatNames" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="imageUploadsAllowed" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="model" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="selectedModels" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="tokenIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="URI"/>
+        <attribute name="useStreamResponse" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="defaultPersona" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PersonaEntity"/>
+    </entity>
+    <entity name="ChatEntity" representedClassName=".ChatEntity" syncable="YES">
+        <attribute name="aiGeneratedSummary" optional="YES" attributeType="String"/>
+        <attribute name="behavior" optional="YES" attributeType="String"/>
+        <attribute name="branchRootID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="branchSourceMessageID" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="branchSourceRole" optional="YES" attributeType="String"/>
+        <attribute name="codexThreadId" optional="YES" attributeType="String"/>
+        <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="gptModel" optional="YES" attributeType="String" defaultValueString="gpt-3.5-turbo"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO" preserveAfterDeletion="YES"/>
+        <attribute name="isPinned" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="newChat" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="newMessage" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="reasoningEffortRaw" optional="YES" attributeType="String"/>
+        <attribute name="requestMessages" optional="YES" attributeType="Transformable" valueTransformerName="RequestMessagesTransformer"/>
+        <attribute name="systemMessage" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="systemMessageProcessed" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="temperature" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="top_p" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="updatedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="waitingForResponse" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="apiService" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APIServiceEntity"/>
+        <relationship name="childChats" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChatEntity" inverseName="parentChat" inverseEntity="ChatEntity"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="MessageEntity" inverseName="chat" inverseEntity="MessageEntity"/>
+        <relationship name="parentChat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChatEntity" inverseName="childChats" inverseEntity="ChatEntity"/>
+        <relationship name="persona" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PersonaEntity"/>
+        <relationship name="project" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProjectEntity" inverseName="chats" inverseEntity="ProjectEntity"/>
+    </entity>
+    <entity name="FileEntity" representedClassName="FileEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="blobID" optional="YES" attributeType="String"/>
+        <attribute name="fileName" optional="YES" attributeType="String"/>
+        <attribute name="fileSize" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="fileType" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="imageData" optional="YES" attributeType="Binary"/>
+        <attribute name="textContent" optional="YES" attributeType="String"/>
+        <attribute name="thumbnailData" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="ImageEntity" representedClassName="ImageEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="image" attributeType="Binary"/>
+        <attribute name="imageFormat" optional="YES" attributeType="String" defaultValueString="jpeg"/>
+        <attribute name="thumbnail" attributeType="Binary"/>
+    </entity>
+    <entity name="MessageEntity" representedClassName=".MessageEntity" syncable="YES">
+        <attribute name="agentModel" optional="YES" attributeType="String"/>
+        <attribute name="agentServiceName" optional="YES" attributeType="String"/>
+        <attribute name="agentServiceType" optional="YES" attributeType="String"/>
+        <attribute name="body" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isMultiAgentResponse" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="multiAgentGroupId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="own" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="searchMetadataJson" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="toolCallsJson" optional="YES" attributeType="String"/>
+        <attribute name="waitingForResponse" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChatEntity" inverseName="messages" inverseEntity="ChatEntity"/>
+    </entity>
+    <entity name="PersonaEntity" representedClassName="PersonaEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="addedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="color" optional="YES" attributeType="String"/>
+        <attribute name="editedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="systemMessage" optional="YES" attributeType="String"/>
+        <attribute name="temperature" optional="YES" attributeType="Float" minValueString="0" maxValueString="1" defaultValueString="0.7" usesScalarValueType="YES"/>
+        <relationship name="defaultApiService" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APIServiceEntity"/>
+    </entity>
+    <entity name="ProjectEntity" representedClassName="ProjectEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="aiGeneratedSummary" optional="YES" attributeType="String"/>
+        <attribute name="colorCode" optional="YES" attributeType="String" defaultValueString="#007AFF"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customInstructions" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastSummarizedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="projectDescription" optional="YES" attributeType="String"/>
+        <attribute name="sortOrder" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="chats" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChatEntity" inverseName="project" inverseEntity="ChatEntity"/>
+    </entity>
+</model>

--- a/Warden/Store/wardenDataModel.xcdatamodeld/wardenDataModel.xcdatamodel/contents
+++ b/Warden/Store/wardenDataModel.xcdatamodeld/wardenDataModel.xcdatamodel/contents
@@ -103,7 +103,7 @@
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="chats" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChatEntity" inverseName="project" inverseEntity="ChatEntity"/>
     </entity>
-    <entity name="PromptEntity" representedClassName="PromptEntity" syncable="YES" codeGenerationType="class">
+    <entity name="PromptEntity" representedClassName="PromptEntity" syncable="YES">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="content" optional="YES" attributeType="String"/>
@@ -113,7 +113,7 @@
         <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastUsedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
-    <entity name="UsageRecordEntity" representedClassName="UsageRecordEntity" syncable="YES" codeGenerationType="class">
+    <entity name="UsageRecordEntity" representedClassName="UsageRecordEntity" syncable="YES">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="providerName" optional="YES" attributeType="String"/>

--- a/Warden/Store/wardenDataModel.xcdatamodeld/wardenDataModel.xcdatamodel/contents
+++ b/Warden/Store/wardenDataModel.xcdatamodeld/wardenDataModel.xcdatamodel/contents
@@ -103,4 +103,27 @@
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="chats" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChatEntity" inverseName="project" inverseEntity="ChatEntity"/>
     </entity>
+    <entity name="PromptEntity" representedClassName="PromptEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="shortcut" optional="YES" attributeType="String"/>
+        <attribute name="category" optional="YES" attributeType="String"/>
+        <attribute name="usageCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastUsedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="UsageRecordEntity" representedClassName="UsageRecordEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="providerName" optional="YES" attributeType="String"/>
+        <attribute name="modelId" optional="YES" attributeType="String"/>
+        <attribute name="chatID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="inputTokens" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="outputTokens" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="cachedInputTokens" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="reasoningTokens" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="estimatedCostUSD" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="pricingSource" optional="YES" attributeType="String"/>
+    </entity>
 </model>

--- a/Warden/UI/Chat/BottomContainer/MessageInputView.swift
+++ b/Warden/UI/Chat/BottomContainer/MessageInputView.swift
@@ -36,6 +36,7 @@ struct MessageInputView: View {
     var focusToken: Int = 0
     
     @StateObject private var mcpManager = MCPManager.shared
+    @StateObject private var promptCompletion = PromptCompletionState()
 
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.wardenTheme) private var theme
@@ -77,8 +78,21 @@ struct MessageInputView: View {
     var body: some View {
         VStack(spacing: 0) {
             attachmentPreviewsSection
-            
+
             VStack(alignment: .leading, spacing: 10) {
+                // "/" prompt-completion suggestions float above the text input
+                if promptCompletion.isVisible {
+                    PromptCompletionListView(state: promptCompletion) { prompt in
+                        if let newText = promptCompletion.acceptSelected(
+                            currentText: state.text,
+                            libraryManager: .shared
+                        ) {
+                            state.text = newText
+                        }
+                    }
+                    .padding(.bottom, 4)
+                }
+
                 // Text Input Area
                 textInputArea
                 
@@ -513,9 +527,13 @@ struct MessageInputView: View {
                     onEnter()
                 },
                 font: NSFont.systemFont(ofSize: CGFloat(effectiveFontSize)),
-                maxHeight: maxInputHeight
+                maxHeight: maxInputHeight,
+                completionState: promptCompletion
             )
             .frame(height: dynamicHeight)
+            .onChange(of: state.text) { _, newText in
+                promptCompletion.sync(with: newText)
+            }
         }
         .padding(.vertical, 0)
         .frame(minWidth: 200)

--- a/Warden/UI/Chat/BottomContainer/MessageInputView.swift
+++ b/Warden/UI/Chat/BottomContainer/MessageInputView.swift
@@ -85,7 +85,8 @@ struct MessageInputView: View {
                     PromptCompletionListView(state: promptCompletion) { prompt in
                         if let newText = promptCompletion.acceptSelected(
                             currentText: state.text,
-                            libraryManager: .shared
+                            libraryManager: .shared,
+                            prompt: prompt
                         ) {
                             state.text = newText
                         }
@@ -533,6 +534,11 @@ struct MessageInputView: View {
             .frame(height: dynamicHeight)
             .onChange(of: state.text) { _, newText in
                 promptCompletion.sync(with: newText)
+            }
+            .onAppear {
+                // A composer can be created with a "/query" already in the text;
+                // sync once so suggestions appear without waiting for an edit.
+                promptCompletion.sync(with: state.text)
             }
         }
         .padding(.vertical, 0)

--- a/Warden/UI/Components/PromptCompletionView.swift
+++ b/Warden/UI/Components/PromptCompletionView.swift
@@ -20,7 +20,12 @@ final class PromptCompletionState: ObservableObject {
         self.library = library
     }
 
-    var isVisible: Bool { query != nil }
+    /// Visible only while there is an active query AND at least one suggestion,
+    /// otherwise arrow keys would be consumed with nothing to navigate.
+    var isVisible: Bool {
+        guard query != nil else { return false }
+        return !suggestions.isEmpty
+    }
 
     var suggestions: [PromptEntity] {
         library.prompts(matchingQuery: query)
@@ -63,10 +68,16 @@ final class PromptCompletionState: ObservableObject {
     }
 
     /// Applies the chosen (or top) prompt to the composer text.
+    /// Pass `prompt` explicitly from tap/activation paths; keyboard acceptance
+    /// omits it and uses the currently highlighted row.
     /// Returns the replacement text, or nil if nothing could be applied.
     @discardableResult
-    func acceptSelected(currentText: String, libraryManager: PromptLibraryManager) -> String? {
-        guard let prompt = selectedPrompt,
+    func acceptSelected(
+        currentText: String,
+        libraryManager: PromptLibraryManager,
+        prompt: PromptEntity? = nil
+    ) -> String? {
+        guard let prompt = prompt ?? selectedPrompt,
               let content = prompt.resolvedContent(selection: nil) else {
             return nil
         }

--- a/Warden/UI/Components/PromptCompletionView.swift
+++ b/Warden/UI/Components/PromptCompletionView.swift
@@ -1,0 +1,165 @@
+import CoreData
+import SwiftUI
+
+/// Drives the "/" prompt-completion experience for one composer.
+///
+/// Owns the active query (text after the leading "/") and the highlighted row.
+/// The text editor consults `isVisible` to divert Enter/arrows/Esc; the composer
+/// renders `PromptCompletionListView` while visible.
+@MainActor
+final class PromptCompletionState: ObservableObject {
+    /// Text typed after the "/" trigger. nil = completion not active.
+    @Published var query: String? {
+        didSet { selectedIndex = 0 }
+    }
+    @Published var selectedIndex: Int = 0
+
+    private let library: PromptLibraryManager
+
+    init(library: PromptLibraryManager = .shared) {
+        self.library = library
+    }
+
+    var isVisible: Bool { query != nil }
+
+    var suggestions: [PromptEntity] {
+        library.prompts(matchingQuery: query)
+    }
+
+    var selectedPrompt: PromptEntity? {
+        let items = suggestions
+        guard !items.isEmpty else { return nil }
+        let index = min(max(selectedIndex, 0), items.count - 1)
+        return items[index]
+    }
+
+    /// Parses composer text into an active query: a line that is exactly "/..." .
+    static func activeQuery(in text: String) -> String? {
+        guard let lastLine = text.split(separator: "\n", omittingEmptySubsequences: false).last else {
+            return nil
+        }
+        guard lastLine.hasPrefix("/"), lastLine.count >= 1 else { return nil }
+        let query = String(lastLine.dropFirst())
+        // A space after the command ends completion — the user moved on.
+        guard !query.contains(" ") else { return nil }
+        return query
+    }
+
+    func sync(with text: String) {
+        let parsed = Self.activeQuery(in: text)
+        if parsed != query {
+            query = parsed
+        }
+    }
+
+    func dismiss() {
+        query = nil
+    }
+
+    func moveSelection(_ delta: Int) {
+        let count = suggestions.count
+        guard count > 0 else { return }
+        selectedIndex = (selectedIndex + delta + count) % count
+    }
+
+    /// Applies the chosen (or top) prompt to the composer text.
+    /// Returns the replacement text, or nil if nothing could be applied.
+    @discardableResult
+    func acceptSelected(currentText: String, libraryManager: PromptLibraryManager) -> String? {
+        guard let prompt = selectedPrompt,
+              let content = prompt.resolvedContent(selection: nil) else {
+            return nil
+        }
+
+        libraryManager.recordUse(prompt)
+
+        // Replace the trailing "/query" line with the resolved content.
+        var lines = currentText.split(separator: "\n", omittingEmptySubsequences: false)
+        if let lastLineIndex = lines.indices.last, lines[lastLineIndex].hasPrefix("/") {
+            lines[lastLineIndex] = Substring(content)
+        } else {
+            lines.append(Substring(content))
+        }
+        let newText = lines.joined(separator: "\n")
+        dismiss()
+        return newText
+    }
+}
+
+/// Floating suggestion list shown above the composer while a "/" query is active.
+struct PromptCompletionListView: View {
+    @ObservedObject var state: PromptCompletionState
+    var onSelect: (PromptEntity) -> Void
+    @Environment(\.wardenTheme) private var theme
+
+    var body: some View {
+        let items = state.suggestions
+        Group {
+            if !items.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(items.enumerated()), id: \.element.objectID) { index, prompt in
+                        PromptCompletionRow(
+                            prompt: prompt,
+                            isHighlighted: index == state.selectedIndex
+                        )
+                        .contentShape(Rectangle())
+                        .onHover { hovering in
+                            if hovering { state.selectedIndex = index }
+                        }
+                        .onTapGesture { onSelect(prompt) }
+                    }
+                }
+                .padding(6)
+                .frame(width: 380)
+                .background(theme.surfaceBackground)
+                .cornerRadius(10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(theme.surfaceBorder, lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.18), radius: 12, y: 4)
+            }
+        }
+    }
+}
+
+private struct PromptCompletionRow: View {
+    let prompt: PromptEntity
+    let isHighlighted: Bool
+    @Environment(\.wardenTheme) private var theme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "text.bubble")
+                .font(.system(size: 11))
+                .foregroundColor(isHighlighted ? .accentColor : .secondary)
+
+            Text(prompt.commandTrigger)
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+
+            Text(prompt.name ?? "")
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            if let category = prompt.category, !category.isEmpty {
+                Text(category)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule().fill(Color.primary.opacity(0.06))
+                    )
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHighlighted ? Color.accentColor.opacity(0.12) : Color.clear)
+        )
+    }
+}

--- a/Warden/UI/Components/SubmitTextEditor.swift
+++ b/Warden/UI/Components/SubmitTextEditor.swift
@@ -116,9 +116,11 @@ struct SubmitTextEditor: NSViewRepresentable {
 
             switch command {
             case .moveDown:
+                guard !state.suggestions.isEmpty else { return false }
                 state.moveSelection(1)
                 return true
             case .moveUp:
+                guard !state.suggestions.isEmpty else { return false }
                 state.moveSelection(-1)
                 return true
             case .escape:
@@ -186,10 +188,13 @@ private final class SubmitAwareTextView: NSTextView {
     }
 
     /// Maps arrow/escape/return key presses to completion commands.
-    /// Arrows are only claimed when "/" completion is actually active (non-nil handler + visible state),
-    /// so normal cursor movement is unaffected otherwise.
+    /// Only unmodified keys are claimed (Shift/Cmd/Opt/Ctrl combos keep their normal
+    /// behavior, e.g. Shift+Return newline), and only while "/" completion is actually
+    /// active, so normal cursor movement is unaffected otherwise.
     private func completionCommand(for event: NSEvent) -> CompletionCommand? {
         guard onCompletionCommand != nil else { return nil }
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard flags.subtracting(.function).subtracting(.numericPad).isEmpty else { return nil }
         switch event.keyCode {
         case 125: return .moveDown   // Down arrow
         case 126: return .moveUp     // Up arrow

--- a/Warden/UI/Components/SubmitTextEditor.swift
+++ b/Warden/UI/Components/SubmitTextEditor.swift
@@ -34,7 +34,9 @@ struct SubmitTextEditor: NSViewRepresentable {
             coordinator?.handleSubmit()
         }
         textView.onCompletionCommand = { [weak coordinator = context.coordinator] command in
-            coordinator?.handleCompletionCommand(command)
+            MainActor.assumeIsolated {
+                coordinator?.handleCompletionCommand(command) ?? false
+            }
         }
         
         // Transparent background
@@ -103,6 +105,7 @@ struct SubmitTextEditor: NSViewRepresentable {
             }
         }
 
+        @MainActor
         func handleSubmit() {
             DispatchQueue.main.async {
                 self.parent.onSubmit()
@@ -111,7 +114,8 @@ struct SubmitTextEditor: NSViewRepresentable {
 
         /// Returns true when the command was consumed by "/" completion (and should not
         /// perform its default action, e.g. submitting on Enter).
-        func handleCompletionCommand(_ command: SubmitAwareTextView.CompletionCommand) -> Bool {
+        @MainActor
+        fileprivate func handleCompletionCommand(_ command: SubmitAwareTextView.CompletionCommand) -> Bool {
             guard let state = parent.completionState, state.isVisible else { return false }
 
             switch command {
@@ -154,7 +158,7 @@ struct SubmitTextEditor: NSViewRepresentable {
                 if let event = NSApp.currentEvent, event.modifierFlags.contains(.shift) {
                     return false // Allow new line with Shift+Enter
                 } else {
-                    handleSubmit()
+                    MainActor.assumeIsolated { handleSubmit() }
                     return true // Consume Enter to submit
                 }
             }
@@ -175,8 +179,11 @@ private final class SubmitAwareTextView: NSTextView {
     }
 
     override func keyDown(with event: NSEvent) {
-        if let command = completionCommand(for: event), onCompletionCommand?(command) {
-            return
+        if let command = completionCommand(for: event) {
+            let consumed = MainActor.assumeIsolated { onCompletionCommand?(command) ?? false }
+            if consumed {
+                return
+            }
         }
 
         if shouldSubmit(for: event) {

--- a/Warden/UI/Components/SubmitTextEditor.swift
+++ b/Warden/UI/Components/SubmitTextEditor.swift
@@ -8,6 +8,8 @@ struct SubmitTextEditor: NSViewRepresentable {
     var onSubmit: () -> Void
     var font: NSFont = .systemFont(ofSize: 14)
     var maxHeight: CGFloat = 160
+    /// When set, arrow/enter/escape are forwarded while "/" completion is active.
+    var completionState: PromptCompletionState?
     
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSScrollView()
@@ -30,6 +32,9 @@ struct SubmitTextEditor: NSViewRepresentable {
         textView.textContainerInset = NSSize(width: 0, height: 8)
         textView.onSubmit = { [weak coordinator = context.coordinator] in
             coordinator?.handleSubmit()
+        }
+        textView.onCompletionCommand = { [weak coordinator = context.coordinator] command in
+            coordinator?.handleCompletionCommand(command)
         }
         
         // Transparent background
@@ -103,6 +108,38 @@ struct SubmitTextEditor: NSViewRepresentable {
                 self.parent.onSubmit()
             }
         }
+
+        /// Returns true when the command was consumed by "/" completion (and should not
+        /// perform its default action, e.g. submitting on Enter).
+        func handleCompletionCommand(_ command: SubmitAwareTextView.CompletionCommand) -> Bool {
+            guard let state = parent.completionState, state.isVisible else { return false }
+
+            switch command {
+            case .moveDown:
+                state.moveSelection(1)
+                return true
+            case .moveUp:
+                state.moveSelection(-1)
+                return true
+            case .escape:
+                state.dismiss()
+                return true
+            case .enter:
+                if state.suggestions.isEmpty { return false }
+                guard let newText = state.acceptSelected(
+                    currentText: parent.text,
+                    libraryManager: .shared
+                ) else { return false }
+                parent.text = newText
+                // Keep the editor view in sync immediately.
+                DispatchQueue.main.async {
+                    if let textView = NSApp.keyWindow?.firstResponder as? NSTextView {
+                        textView.string = newText
+                    }
+                }
+                return true
+            }
+        }
         
         func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
             let submitCommands: [Selector] = [
@@ -126,14 +163,40 @@ struct SubmitTextEditor: NSViewRepresentable {
 
 private final class SubmitAwareTextView: NSTextView {
     var onSubmit: (() -> Void)?
+    var onCompletionCommand: ((CompletionCommand) -> Bool)?
+
+    enum CompletionCommand {
+        case moveUp
+        case moveDown
+        case escape
+        case enter
+    }
 
     override func keyDown(with event: NSEvent) {
+        if let command = completionCommand(for: event), onCompletionCommand?(command) {
+            return
+        }
+
         if shouldSubmit(for: event) {
             onSubmit?()
             return
         }
 
         super.keyDown(with: event)
+    }
+
+    /// Maps arrow/escape/return key presses to completion commands.
+    /// Arrows are only claimed when "/" completion is actually active (non-nil handler + visible state),
+    /// so normal cursor movement is unaffected otherwise.
+    private func completionCommand(for event: NSEvent) -> CompletionCommand? {
+        guard onCompletionCommand != nil else { return nil }
+        switch event.keyCode {
+        case 125: return .moveDown   // Down arrow
+        case 126: return .moveUp     // Up arrow
+        case 53: return .escape      // Escape
+        case 36, 76: return .enter   // Return / keypad Enter
+        default: return nil
+        }
     }
 
     private func shouldSubmit(for event: NSEvent) -> Bool {

--- a/Warden/UI/Preferences/PreferencesView.swift
+++ b/Warden/UI/Preferences/PreferencesView.swift
@@ -6,6 +6,8 @@ enum PreferencesTabs: String, CaseIterable, Identifiable {
     case general = "General"
     case apiServices = "API Services"
     case aiPersonas = "AI Assistants"
+    case promptLibrary = "Prompt Library"
+    case usageTracking = "Usage"
     case tools = "Tools"
     case keyboardShortcuts = "Keyboard Shortcuts"
     case contributions = "Contributions"
@@ -17,6 +19,8 @@ enum PreferencesTabs: String, CaseIterable, Identifiable {
         case .general: return "gearshape.fill"
         case .apiServices: return "network"
         case .aiPersonas: return "person.2.fill"
+        case .promptLibrary: return "text.bubble.fill"
+        case .usageTracking: return "chart.bar.fill"
         case .tools: return "wrench.and.screwdriver.fill"
         case .keyboardShortcuts: return "keyboard.fill"
         case .contributions: return "heart.fill"
@@ -28,6 +32,8 @@ enum PreferencesTabs: String, CaseIterable, Identifiable {
         case .general: return .gray
         case .apiServices: return .blue
         case .aiPersonas: return .purple
+        case .promptLibrary: return .teal
+        case .usageTracking: return .mint
         case .tools: return .orange
         case .keyboardShortcuts: return .green
         case .contributions: return .pink
@@ -89,6 +95,12 @@ struct SettingsDetailView: View {
                 TabAPIServicesView()
             case .aiPersonas:
                 TabAIPersonasView()
+                    .environment(\.managedObjectContext, viewContext)
+            case .promptLibrary:
+                TabPromptLibraryView()
+                    .environment(\.managedObjectContext, viewContext)
+            case .usageTracking:
+                TabUsageView()
                     .environment(\.managedObjectContext, viewContext)
             case .tools:
                 TabToolsView()

--- a/Warden/UI/Preferences/TabPromptLibraryView.swift
+++ b/Warden/UI/Preferences/TabPromptLibraryView.swift
@@ -1,0 +1,280 @@
+import CoreData
+import SwiftUI
+
+/// Prompt library management inside Preferences: list, add/edit sheet, delete.
+@MainActor
+struct TabPromptLibraryView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @FetchRequest(
+        sortDescriptors: [
+            NSSortDescriptor(keyPath: \PromptEntity.category, ascending: true),
+            NSSortDescriptor(keyPath: \PromptEntity.name, ascending: true),
+        ],
+        animation: .default
+    )
+    private var prompts: FetchedResults<PromptEntity>
+
+    @State private var promptInSheet: PromptInSheet?
+    @State private var promptToDelete: PromptEntity?
+    @State private var showingDeleteConfirmation = false
+
+    struct PromptInSheet: Identifiable {
+        let id: NSManagedObjectID
+        var entity: PromptEntity? {
+            try? PersistenceController.shared.container.viewContext.object(with: id) as? PromptEntity
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                GlassCard {
+                    VStack(alignment: .leading, spacing: 14) {
+                        HStack {
+                            SettingsSectionHeader(title: "Your Prompts")
+                            Spacer()
+                            Button {
+                                onAdd()
+                            } label: {
+                                Label("Add Prompt", systemImage: "plus.circle")
+                            }
+                            .buttonStyle(.bordered)
+                        }
+
+                        Text("Type / in any chat input to insert a prompt. Use {{text}} as a placeholder for pasted or selected content.")
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        if prompts.isEmpty {
+                            Text("No prompts yet. Add one to get started.")
+                                .font(.system(size: 13))
+                                .foregroundColor(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.vertical, 32)
+                        } else {
+                            promptList
+                        }
+                    }
+                    .padding(16)
+                }
+            }
+            .padding(20)
+        }
+        .sheet(item: $promptInSheet) { item in
+            PromptEditSheet(prompt: item.entity)
+                .environment(\.managedObjectContext, viewContext)
+        }
+        .confirmationDialog(
+            "Delete this prompt?",
+            isPresented: $showingDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let target = promptToDelete {
+                    PromptLibraryManager.shared.delete(target)
+                }
+                promptToDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                promptToDelete = nil
+            }
+        } message: {
+            Text("This cannot be undone.")
+        }
+    }
+
+    private var promptList: some View {
+        VStack(spacing: 0) {
+            ForEach(prompts, id: \.objectID) { prompt in
+                PromptListRow(
+                    prompt: prompt,
+                    onEdit: { promptInSheet = PromptInSheet(id: prompt.objectID) },
+                    onDelete: {
+                        promptToDelete = prompt
+                        showingDeleteConfirmation = true
+                    }
+                )
+                if prompt.objectID != prompts.last?.objectID {
+                    Divider().opacity(0.5)
+                }
+            }
+        }
+        .background(Color.primary.opacity(0.03))
+        .cornerRadius(8)
+    }
+
+    private func onAdd() {
+        let newPrompt = PromptLibraryManager.shared.addPrompt(name: "", content: "")
+        promptInSheet = PromptInSheet(id: newPrompt.objectID)
+    }
+}
+
+private struct PromptListRow: View {
+    @ObservedObject var prompt: PromptEntity
+    var onEdit: () -> Void
+    var onDelete: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "text.bubble")
+                .font(.system(size: 13))
+                .foregroundColor(.accentColor)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(prompt.commandTrigger)
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+
+                    if let category = prompt.category, !category.isEmpty {
+                        Text(category)
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(Color.primary.opacity(0.06)))
+                    }
+                }
+
+                Text(prompt.content ?? "")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if prompt.usageCount > 0 {
+                Text("\(prompt.usageCount)x")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+
+            HStack(spacing: 4) {
+                Button(action: onEdit) {
+                    Image(systemName: "pencil")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.borderless)
+                .help("Edit")
+
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                        .font(.system(size: 11))
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(.borderless)
+                .help("Delete")
+            }
+            .opacity(isHovered ? 1 : 0.35)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(isHovered ? Color.primary.opacity(0.04) : Color.clear)
+        .onHover { isHovered = $0 }
+    }
+}
+
+/// Add-or-edit sheet. Pass nil to create a fresh prompt.
+private struct PromptEditSheet: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.dismiss) private var dismiss
+
+    let prompt: PromptEntity?
+
+    @State private var name = ""
+    @State private var content = ""
+    @State private var shortcut = ""
+    @State private var category = ""
+    @State private var didLoad = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(prompt == nil ? "New Prompt" : "Edit Prompt")
+                .font(.system(size: 15, weight: .semibold))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Name").font(.system(size: 11)).foregroundColor(.secondary)
+                TextField("e.g. Explain This", text: $name)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Content").font(.system(size: 11)).foregroundColor(.secondary)
+                TextEditor(text: $content)
+                    .font(.system(size: 13))
+                    .frame(minHeight: 140)
+                    .border(Color.primary.opacity(0.15))
+            }
+
+            HStack(alignment: .top, spacing: 14) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Shortcut (for /command)").font(.system(size: 11)).foregroundColor(.secondary)
+                    TextField("explain", text: $shortcut)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 160)
+                }
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Category (optional)").font(.system(size: 11)).foregroundColor(.secondary)
+                    TextField("Writing", text: $category)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 160)
+                }
+                Spacer()
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+
+                Button("Save") {
+                    save()
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 520)
+        .onAppear {
+            guard !didLoad else { return }
+            didLoad = true
+            if let p = prompt {
+                name = p.name ?? ""
+                content = p.content ?? ""
+                shortcut = p.shortcut ?? ""
+                category = p.category ?? ""
+            }
+        }
+    }
+
+    private func save() {
+        let trimmedShortcut = shortcut.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let trimmedCategory = category.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let prompt = prompt {
+            prompt.name = trimmedName.isEmpty ? "Untitled Prompt" : trimmedName
+            prompt.content = content
+            prompt.shortcut = trimmedShortcut.isEmpty ? nil : trimmedShortcut
+            prompt.category = trimmedCategory.isEmpty ? nil : trimmedCategory
+        } else {
+            _ = PromptLibraryManager.shared.addPrompt(
+                name: trimmedName.isEmpty ? "Untitled Prompt" : trimmedName,
+                content: content,
+                shortcut: trimmedShortcut.isEmpty ? nil : trimmedShortcut,
+                category: trimmedCategory.isEmpty ? nil : trimmedCategory
+            )
+        }
+
+        do {
+            try viewContext.save()
+        } catch {
+            WardenLog.app.error("[Prompts] Sheet save failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/Warden/UI/Preferences/TabPromptLibraryView.swift
+++ b/Warden/UI/Preferences/TabPromptLibraryView.swift
@@ -15,13 +15,16 @@ struct TabPromptLibraryView: View {
     private var prompts: FetchedResults<PromptEntity>
 
     @State private var promptInSheet: PromptInSheet?
+    @State private var newPromptSheetIsPresented = false
     @State private var promptToDelete: PromptEntity?
     @State private var showingDeleteConfirmation = false
 
     struct PromptInSheet: Identifiable {
         let id: NSManagedObjectID
-        var entity: PromptEntity? {
-            try? PersistenceController.shared.container.viewContext.object(with: id) as? PromptEntity
+        /// Resolve through `existingObject(with:)` so a deleted prompt yields nil
+        /// instead of an unfulfillable fault that would crash the edit sheet.
+        func entity(in context: NSManagedObjectContext) -> PromptEntity? {
+            try? context.existingObject(with: id) as? PromptEntity
         }
     }
 
@@ -62,7 +65,11 @@ struct TabPromptLibraryView: View {
             .padding(20)
         }
         .sheet(item: $promptInSheet) { item in
-            PromptEditSheet(prompt: item.entity)
+            PromptEditSheet(prompt: item.entity(in: viewContext))
+                .environment(\.managedObjectContext, viewContext)
+        }
+        .sheet(isPresented: $newPromptSheetIsPresented) {
+            PromptEditSheet(prompt: nil)
                 .environment(\.managedObjectContext, viewContext)
         }
         .confirmationDialog(
@@ -105,8 +112,9 @@ struct TabPromptLibraryView: View {
     }
 
     private func onAdd() {
-        let newPrompt = PromptLibraryManager.shared.addPrompt(name: "", content: "")
-        promptInSheet = PromptInSheet(id: newPrompt.objectID)
+        // Don't create anything here — only the sheet's Save persists a new prompt.
+        // Creating up front would leak an empty prompt if the user cancels.
+        newPromptSheetIsPresented = true
     }
 }
 

--- a/Warden/UI/Preferences/TabUsageView.swift
+++ b/Warden/UI/Preferences/TabUsageView.swift
@@ -1,0 +1,249 @@
+import CoreData
+import SwiftUI
+import Charts
+
+/// Usage & cost dashboard: totals, daily cost chart, per-model breakdown.
+@MainActor
+struct TabUsageView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+
+    enum TimeWindow: String, CaseIterable, Identifiable {
+        case sevenDays = "7 Days"
+        case thirtyDays = "30 Days"
+        case allTime = "All Time"
+
+        var id: String { rawValue }
+
+        var startDate: Date? {
+            switch self {
+            case .sevenDays:
+                return Calendar.current.date(byAdding: .day, value: -6, to: Calendar.current.startOfDay(for: Date()))
+            case .thirtyDays:
+                return Calendar.current.date(byAdding: .day, value: -29, to: Calendar.current.startOfDay(for: Date()))
+            case .allTime:
+                return nil
+            }
+        }
+
+        var dayCountForChart: Int? {
+            switch self {
+            case .sevenDays: return 7
+            case .thirtyDays: return 30
+            case .allTime: return nil
+            }
+        }
+    }
+
+    @State private var window: TimeWindow = .thirtyDays
+
+    private let service = UsageTrackingService()
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+
+                totalsCards
+
+                if window.dayCountForChart != nil {
+                    dailyChartCard
+                }
+
+                modelBreakdownCard
+            }
+            .padding(20)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        HStack {
+            SettingsSectionHeader(title: "Usage & Cost")
+            Spacer()
+            Picker("", selection: $window) {
+                ForEach(TimeWindow.allCases) { window in
+                    Text(window.rawValue).tag(window)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 280)
+        }
+    }
+
+    private var totalsCards: some View {
+        let totals = service.totals(from: window.startDate)
+        let columns = [
+            GridItem(.flexible()),
+            GridItem(.flexible()),
+            GridItem(.flexible()),
+            GridItem(.flexible()),
+        ]
+
+        return LazyVGrid(columns: columns, spacing: 12) {
+            usageStatCard(
+                title: "Estimated Spend",
+                value: formatUSD(totals.costUSD),
+                icon: "dollarsign.circle.fill",
+                color: .mint,
+                subtitle: window == .allTime ? "since tracking began" : "last \(window.rawValue.lowercased())"
+            )
+            usageStatCard(
+                title: "Input Tokens",
+                value: formatTokenCount(totals.inputTokens),
+                icon: "arrow.down.circle",
+                color: .blue,
+                subtitle: ""
+            )
+            usageStatCard(
+                title: "Output Tokens",
+                value: formatTokenCount(totals.outputTokens),
+                icon: "arrow.up.circle",
+                color: .purple,
+                subtitle: ""
+            )
+            usageStatCard(
+                title: "Requests",
+                value: "\(totals.requestCount)",
+                icon: "bubble.left.and.bubble.right",
+                color: .orange,
+                subtitle: ""
+            )
+        }
+    }
+
+    private func usageStatCard(title: String, value: String, icon: String, color: Color, subtitle: String) -> some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 6) {
+                Label(title, systemImage: icon)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                Text(value)
+                    .font(.system(size: 22, weight: .semibold, design: .rounded))
+                if !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(14)
+        }
+    }
+
+    private var dailyChartCard: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Daily Cost")
+                    .font(.system(size: 13, weight: .medium))
+
+                let days = service.dailyTotals(days: window.dayCountForChart ?? 30)
+                if days.allSatisfy({ $0.totals.costUSD == 0 }) && !days.isEmpty {
+                    Text("No recorded spend in this window yet.")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 24)
+                } else {
+                    Chart(days, id: \.date) { entry in
+                        BarMark(
+                            x: .value("Day", entry.date, unit: .day),
+                            y: .value("Cost", entry.totals.costUSD)
+                        )
+                        .foregroundStyle(Color.mint.gradient)
+                        .cornerRadius(2)
+                    }
+                    .chartXAxis {
+                        AxisMarks(values: .stride(by: .day)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                                .font(.system(size: 9))
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine()
+                            AxisValueLabel()
+                                .font(.system(size: 9))
+                        }
+                    }
+                    .frame(height: 180)
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private var modelBreakdownCard: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("By Model")
+                    .font(.system(size: 13, weight: .medium))
+
+                let breakdown = service.breakdownByModel(from: window.startDate)
+                if breakdown.isEmpty {
+                    Text("No usage recorded in this window yet. Send a message to start tracking.")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 24)
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(breakdown) { entry in
+                            HStack(spacing: 12) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(entry.providerName)
+                                        .font(.system(size: 13, weight: .medium))
+                                    Text(entry.id)
+                                        .font(.system(size: 11, design: .monospaced))
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                }
+
+                                Spacer()
+
+                                VStack(alignment: .trailing, spacing: 2) {
+                                    Text(formatUSD(entry.totals.costUSD))
+                                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                                    Text("\(formatTokenCount(entry.totals.inputTokens)) in · \(formatTokenCount(entry.totals.outputTokens)) out")
+                                        .font(.system(size: 10))
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                            .padding(.vertical, 8)
+
+                            if entry.id != breakdown.last?.id {
+                                Divider().opacity(0.5)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func formatUSD(_ amount: Double) -> String {
+        if amount >= 100 {
+            return String(format: "$%.0f", amount)
+        } else if amount >= 1 {
+            return String(format: "$%.2f", amount)
+        } else if amount > 0 {
+            return String(format: "$%.4f", amount)
+        }
+        return "$0.00"
+    }
+
+    private func formatTokenCount(_ count: Int64) -> String {
+        switch count {
+        case 1_000_000...:
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        case 1_000...:
+            return String(format: "%.1fk", Double(count) / 1_000)
+        default:
+            return "\(count)"
+        }
+    }
+}

--- a/Warden/UI/Preferences/TabUsageView.swift
+++ b/Warden/UI/Preferences/TabUsageView.swift
@@ -35,6 +35,8 @@ struct TabUsageView: View {
     }
 
     @State private var window: TimeWindow = .thirtyDays
+    /// Bumped whenever usage records change so computed cards/chart re-render.
+    @State private var refreshTrigger = 0
 
     private let service = UsageTrackingService()
 
@@ -53,6 +55,15 @@ struct TabUsageView: View {
             }
             .padding(20)
         }
+        .id(refreshTrigger)
+        .onReceive(NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)) { note in
+            // Re-render when any save touches a UsageRecordEntity (e.g. a completion
+            // finishing in another window while this tab is open).
+            if let objects = note.object as? Set<NSManagedObject>,
+               objects.contains(where: { $0 is UsageRecordEntity }) {
+                refreshTrigger &+= 1
+            }
+        }
     }
 
     // MARK: - Sections
@@ -61,7 +72,7 @@ struct TabUsageView: View {
         HStack {
             SettingsSectionHeader(title: "Usage & Cost")
             Spacer()
-            Picker("", selection: $window) {
+            Picker("Time Window", selection: $window) {
                 ForEach(TimeWindow.allCases) { window in
                     Text(window.rawValue).tag(window)
                 }
@@ -117,7 +128,7 @@ struct TabUsageView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Label(title, systemImage: icon)
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(color)
                 Text(value)
                     .font(.system(size: 22, weight: .semibold, design: .rounded))
                 if !subtitle.isEmpty {
@@ -194,7 +205,7 @@ struct TabUsageView: View {
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(entry.providerName)
                                         .font(.system(size: 13, weight: .medium))
-                                    Text(entry.id)
+                                    Text(entry.modelId)
                                         .font(.system(size: 11, design: .monospaced))
                                         .foregroundColor(.secondary)
                                         .lineLimit(1)
@@ -226,24 +237,32 @@ struct TabUsageView: View {
     // MARK: - Formatting
 
     private func formatUSD(_ amount: Double) -> String {
+        // Locale-aware currency formatting, pinned to USD (pricing source is USD).
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
         if amount >= 100 {
-            return String(format: "$%.0f", amount)
+            formatter.maximumFractionDigits = 0
         } else if amount >= 1 {
-            return String(format: "$%.2f", amount)
-        } else if amount > 0 {
-            return String(format: "$%.4f", amount)
+            formatter.maximumFractionDigits = 2
+            formatter.minimumFractionDigits = 2
+        } else {
+            formatter.maximumFractionDigits = 4
+            formatter.minimumFractionDigits = amount > 0 ? 4 : 2
         }
-        return "$0.00"
+        return formatter.string(from: NSNumber(value: amount)) ?? "$\(amount)"
     }
 
     private func formatTokenCount(_ count: Int64) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal  // Respects the user's grouping/decimal separators
         switch count {
         case 1_000_000...:
-            return String(format: "%.1fM", Double(count) / 1_000_000)
+            return String(format: "%.1fM", locale: Locale.current, Double(count) / 1_000_000)
         case 1_000...:
-            return String(format: "%.1fk", Double(count) / 1_000)
+            return String(format: "%.1fk", locale: Locale.current, Double(count) / 1_000)
         default:
-            return "\(count)"
+            return formatter.string(from: NSNumber(value: count)) ?? "\(count)"
         }
     }
 }

--- a/Warden/Utilities/APIHandlers/APIProtocol.swift
+++ b/Warden/Utilities/APIHandlers/APIProtocol.swift
@@ -61,8 +61,31 @@ protocol APIService {
     ) async throws -> URLRequest
     
     func parseJSONResponse(data: Data) -> (String?, String?, [ToolCall]?)?
-    
+
     func parseDeltaJSONResponse(data: Data?) -> (Bool, Error?, String?, String?, [ToolCall]?)
+
+    // MARK: - Usage Capture
+
+    /// Begins a usage capture scope for one request; returns its request ID.
+    func beginUsageCapture() -> UUID
+
+    /// Records token usage seen in a response payload for the active request scope.
+    func captureUsage(_ usage: TokenUsage)
+
+    /// Returns and clears the usage captured for `requestID`.
+    func consumeCapturedUsage(for requestID: UUID) -> TokenUsage?
+
+    /// Discards usage captured for `requestID` without recording it.
+    func discardCapturedUsage(for requestID: UUID)
+}
+
+/// Default no-op implementations so conformers that don't support usage capture
+/// still satisfy the protocol (they simply report nothing).
+extension APIService {
+    func beginUsageCapture() -> UUID { UUID() }
+    func captureUsage(_ usage: TokenUsage) {}
+    func consumeCapturedUsage(for requestID: UUID) -> TokenUsage? { nil }
+    func discardCapturedUsage(for requestID: UUID) {}
 }
 
 protocol APIServiceConfiguration {
@@ -149,11 +172,11 @@ extension APIService {
             switch result {
             case .success(let responseData):
                 if let responseData = responseData {
-                    // Capture token usage from the non-streaming response body.
+                    // Capture token usage from the non-streaming response body,
+                    // scoped to this request.
                     if let json = try? JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any],
-                       let usage = UsageExtractor.extract(from: json),
-                       let baseHandler = self as? BaseAPIHandler {
-                        baseHandler.captureUsage(usage)
+                       let usage = UsageExtractor.extract(from: json) {
+                        captureUsage(usage)
                     }
 
                     guard let (messageContent, _, toolCalls) = self.parseJSONResponse(data: responseData) else {

--- a/Warden/Utilities/APIHandlers/APIProtocol.swift
+++ b/Warden/Utilities/APIHandlers/APIProtocol.swift
@@ -149,6 +149,13 @@ extension APIService {
             switch result {
             case .success(let responseData):
                 if let responseData = responseData {
+                    // Capture token usage from the non-streaming response body.
+                    if let json = try? JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any],
+                       let usage = UsageExtractor.extract(from: json),
+                       let baseHandler = self as? BaseAPIHandler {
+                        baseHandler.captureUsage(usage)
+                    }
+
                     guard let (messageContent, _, toolCalls) = self.parseJSONResponse(data: responseData) else {
                         #if DEBUG
                         WardenLog.app.debug(

--- a/Warden/Utilities/APIHandlers/BaseAPIHandler.swift
+++ b/Warden/Utilities/APIHandlers/BaseAPIHandler.swift
@@ -7,6 +7,12 @@ class BaseAPIHandler: APIService, @unchecked Sendable {
     let model: String
     internal let session: URLSession
     internal let streamingSession: URLSession
+
+    /// Token usage reported by the provider for the most recent completion
+    /// (streaming or non-streaming). Read after a request finishes.
+    /// Guarded by `usageLock` because handlers are used from concurrent tasks.
+    private var lastUsage: TokenUsage?
+    private let usageLock = NSLock()
     
     init(config: APIServiceConfiguration, session: URLSession, streamingSession: URLSession) {
         self.name = config.name
@@ -15,6 +21,24 @@ class BaseAPIHandler: APIService, @unchecked Sendable {
         self.model = config.model
         self.session = session
         self.streamingSession = streamingSession
+    }
+
+    // MARK: - Usage Capture
+
+    /// Records token usage seen in a response payload. Called from parsing paths.
+    func captureUsage(_ usage: TokenUsage) {
+        usageLock.lock()
+        lastUsage = TokenUsage.merged(usage, into: lastUsage)
+        usageLock.unlock()
+    }
+
+    /// Returns and clears the captured usage for the most recent completion.
+    func consumeCapturedUsage() -> TokenUsage? {
+        usageLock.lock()
+        defer { usageLock.unlock() }
+        let usage = lastUsage
+        lastUsage = nil
+        return usage
     }
     
     convenience init(config: APIServiceConfiguration, session: URLSession) {
@@ -131,6 +155,11 @@ class BaseAPIHandler: APIService, @unchecked Sendable {
                             try Task.checkCancellation()
 
                             if let data = dataString.data(using: .utf8) {
+                                // Capture token usage if this chunk carries it (usually the final chunk).
+                                if let usage = UsageExtractor.extract(fromStreamData: data) {
+                                    self.captureUsage(usage)
+                                }
+
                                 let (finished, error, messageData, role, toolCalls) = self.parseDeltaJSONResponse(data: data)
 
                                 if let error = error {

--- a/Warden/Utilities/APIHandlers/BaseAPIHandler.swift
+++ b/Warden/Utilities/APIHandlers/BaseAPIHandler.swift
@@ -8,12 +8,14 @@ class BaseAPIHandler: APIService, @unchecked Sendable {
     internal let session: URLSession
     internal let streamingSession: URLSession
 
-    /// Token usage reported by the provider for the most recent completion
-    /// (streaming or non-streaming). Read after a request finishes.
-    /// Guarded by `usageLock` because handlers are used from concurrent tasks.
-    private var lastUsage: TokenUsage?
+    /// Token usage reported by the provider, keyed by request ID so overlapping or
+    /// retried requests can't inherit each other's usage. Guarded by `usageLock`
+    /// because handlers are used from concurrent tasks.
+    private var pendingUsage: [UUID: TokenUsage] = [:]
+    /// The request a parsing path should attribute captured usage to.
+    private var currentRequestID: UUID?
     private let usageLock = NSLock()
-    
+
     init(config: APIServiceConfiguration, session: URLSession, streamingSession: URLSession) {
         self.name = config.name
         self.baseURL = config.apiUrl
@@ -25,20 +27,40 @@ class BaseAPIHandler: APIService, @unchecked Sendable {
 
     // MARK: - Usage Capture
 
-    /// Records token usage seen in a response payload. Called from parsing paths.
-    func captureUsage(_ usage: TokenUsage) {
+    /// Begins a new capture scope. Usage seen until the matching consume/discard
+    /// is attributed to the returned request ID.
+    func beginUsageCapture() -> UUID {
+        let id = UUID()
         usageLock.lock()
-        lastUsage = TokenUsage.merged(usage, into: lastUsage)
+        currentRequestID = id
+        pendingUsage[id] = nil
         usageLock.unlock()
+        return id
     }
 
-    /// Returns and clears the captured usage for the most recent completion.
-    func consumeCapturedUsage() -> TokenUsage? {
+    /// Records token usage seen in a response payload for the active request scope.
+    func captureUsage(_ usage: TokenUsage) {
         usageLock.lock()
         defer { usageLock.unlock() }
-        let usage = lastUsage
-        lastUsage = nil
-        return usage
+        guard let requestID = currentRequestID else { return }
+        pendingUsage[requestID] = TokenUsage.merged(usage, into: pendingUsage[requestID])
+    }
+
+    /// Returns and clears the usage captured for `requestID`.
+    func consumeCapturedUsage(for requestID: UUID) -> TokenUsage? {
+        usageLock.lock()
+        defer { usageLock.unlock() }
+        currentRequestID = nil
+        return pendingUsage.removeValue(forKey: requestID)
+    }
+
+    /// Discards usage captured for `requestID` without recording it (cancellation,
+    /// errors) so partial reports never reach the usage tracker.
+    func discardCapturedUsage(for requestID: UUID) {
+        usageLock.lock()
+        defer { usageLock.unlock() }
+        if currentRequestID == requestID { currentRequestID = nil }
+        pendingUsage.removeValue(forKey: requestID)
     }
     
     convenience init(config: APIServiceConfiguration, session: URLSession) {
@@ -85,6 +107,7 @@ class BaseAPIHandler: APIService, @unchecked Sendable {
                     await controller.finish()
                     return
                 }
+                let usageRequestID = self.beginUsageCapture()
                 do {
                     var attemptSettings = settings
                     var didRetryWithoutReasoning = false
@@ -155,8 +178,15 @@ class BaseAPIHandler: APIService, @unchecked Sendable {
                             try Task.checkCancellation()
 
                             if let data = dataString.data(using: .utf8) {
-                                // Capture token usage if this chunk carries it (usually the final chunk).
-                                if let usage = UsageExtractor.extract(fromStreamData: data) {
+                                // Capture token usage if this chunk carries it (usually the final
+                                // chunk). Cheap substring check first — most chunks have no usage,
+                                // and this avoids deserializing every SSE event twice.
+                                let looksLikeUsageChunk =
+                                    dataString.contains("\"usage\"")
+                                    || dataString.contains("eval_count")
+                                    || dataString.contains("prompt_eval_count")
+                                if looksLikeUsageChunk,
+                                   let usage = UsageExtractor.extract(fromStreamData: data) {
                                     self.captureUsage(usage)
                                 }
 
@@ -208,9 +238,12 @@ class BaseAPIHandler: APIService, @unchecked Sendable {
                         return
                     }
                 } catch is CancellationError {
-                    // Silently finish on cancellation - don't throw
+                    // Cancelled mid-stream: drop any partially captured usage so a
+                    // partial report is never recorded as a full completion.
+                    self.discardCapturedUsage(for: usageRequestID)
                     await controller.finish()
                 } catch {
+                    self.discardCapturedUsage(for: usageRequestID)
                     await controller.finish(throwing: error)
                 }
             }

--- a/Warden/Utilities/APIServiceManager.swift
+++ b/Warden/Utilities/APIServiceManager.swift
@@ -212,7 +212,27 @@ class APIServiceManager {
         chatID: UUID? = nil,
         onChunk: @MainActor @escaping (String) async -> Void
     ) async throws -> [ToolCall]? {
+        // Begin the capture scope before creating the stream so usage from the very
+        // first chunk is already attributable to this request.
+        let usageRequestID = apiService.beginUsageCapture()
         let stream = try await apiService.sendMessageStream(messages, tools: tools, settings: settings)
+
+        defer {
+            // Record token usage captured by the handler during streaming. Runs on
+            // every exit path (success, error, cancellation) so captured usage is
+            // always consumed and never bleeds into the next request. Best effort —
+            // usage accounting must never break a chat.
+            let usage = apiService.consumeCapturedUsage(for: usageRequestID)
+            if let usage, !usage.isEmpty {
+                UsageTrackingService.shared.record(
+                    usage: usage,
+                    providerName: apiService.name,
+                    modelId: apiService.model,
+                    chatID: chatID
+                )
+            }
+        }
+
         var pendingChunkParts: [String] = []
         var pendingChunkCharacterCount = 0
         let updateInterval = AppConstants.streamedResponseUpdateUIInterval
@@ -297,28 +317,7 @@ class APIServiceManager {
         }
 
         await flushPendingChunkBuffer()
-        
-        #if DEBUG
-        if !didEndTTFT {
-            didEndTTFT = true
-            os_signpost(.end, log: WardenSignpost.streaming, name: "TTFT", signpostID: ttftSignpostID)
-        }
-        os_signpost(.end, log: WardenSignpost.streaming, name: "Stream", signpostID: streamSignpostID)
-        #endif
-        
-        // Record token usage captured by the handler during streaming (best effort —
-        // usage accounting must never break a chat).
-        if let baseHandler = apiService as? BaseAPIHandler {
-            let usage = baseHandler.consumeCapturedUsage()
-            if let usage, !usage.isEmpty {
-                UsageTrackingService.shared.record(
-                    usage: usage,
-                    providerName: apiService.name,
-                    modelId: model,
-                    chatID: chatID
-                )
-            }
-        }
+
 
         return allToolCalls
     }

--- a/Warden/Utilities/APIServiceManager.swift
+++ b/Warden/Utilities/APIServiceManager.swift
@@ -224,12 +224,14 @@ class APIServiceManager {
             // usage accounting must never break a chat.
             let usage = apiService.consumeCapturedUsage(for: usageRequestID)
             if let usage, !usage.isEmpty {
-                UsageTrackingService.shared.record(
-                    usage: usage,
-                    providerName: apiService.name,
-                    modelId: apiService.model,
-                    chatID: chatID
-                )
+                Task { @MainActor in
+                    UsageTrackingService.shared.record(
+                        usage: usage,
+                        providerName: apiService.name,
+                        modelId: apiService.model,
+                        chatID: chatID
+                    )
+                }
             }
         }
 

--- a/Warden/Utilities/APIServiceManager.swift
+++ b/Warden/Utilities/APIServiceManager.swift
@@ -209,6 +209,7 @@ class APIServiceManager {
         messages: [[String: String]],
         tools: [[String: Any]]? = nil,
         settings: GenerationSettings,
+        chatID: UUID? = nil,
         onChunk: @MainActor @escaping (String) async -> Void
     ) async throws -> [ToolCall]? {
         let stream = try await apiService.sendMessageStream(messages, tools: tools, settings: settings)
@@ -305,6 +306,20 @@ class APIServiceManager {
         os_signpost(.end, log: WardenSignpost.streaming, name: "Stream", signpostID: streamSignpostID)
         #endif
         
+        // Record token usage captured by the handler during streaming (best effort —
+        // usage accounting must never break a chat).
+        if let baseHandler = apiService as? BaseAPIHandler {
+            let usage = baseHandler.consumeCapturedUsage()
+            if let usage, !usage.isEmpty {
+                UsageTrackingService.shared.record(
+                    usage: usage,
+                    providerName: apiService.name,
+                    modelId: model,
+                    chatID: chatID
+                )
+            }
+        }
+
         return allToolCalls
     }
     

--- a/Warden/Utilities/ChatService.swift
+++ b/Warden/Utilities/ChatService.swift
@@ -13,6 +13,7 @@ class ChatService {
         messages: [[String: String]],
         tools: [[String: Any]]? = nil,
         settings: GenerationSettings,
+        chatID: UUID? = nil,
         onChunk: @MainActor @escaping (String) async -> Void
     ) async throws -> [ToolCall]? {
         return try await APIServiceManager.handleStream(
@@ -20,6 +21,7 @@ class ChatService {
             messages: messages,
             tools: tools,
             settings: settings,
+            chatID: chatID,
             onChunk: onChunk
         )
     }

--- a/Warden/Utilities/ChatService.swift
+++ b/Warden/Utilities/ChatService.swift
@@ -4,9 +4,9 @@ import Foundation
 /// Unifies single and multi-agent message sending patterns
 class ChatService {
     static let shared = ChatService()
-    
+
     private init() {}
-    
+
     /// Send a message with streaming response
     func sendStream(
         apiService: APIService,
@@ -25,16 +25,35 @@ class ChatService {
             onChunk: onChunk
         )
     }
-    
+
     /// Send a message with non-streaming response
     func sendMessage(
         apiService: APIService,
         messages: [[String: String]],
         tools: [[String: Any]]? = nil,
         settings: GenerationSettings,
+        chatID: UUID? = nil,
         completion: @escaping (Result<(String?, [ToolCall]?), Error>) -> Void
     ) {
-        apiService.sendMessage(messages, tools: tools, settings: settings) { result in
+        let requestID = apiService.beginUsageCapture()
+        apiService.sendMessage(messages, tools: tools, settings: settings) { [weak self] result in
+            // Record token usage captured by the handler for this non-streaming
+            // completion (best effort — usage accounting must never break a chat).
+            // Only the main chat path passes a chatID; auxiliary calls (chat-name
+            // generation, connection tests) leave it nil and are not tracked.
+            if let self, let chatID {
+                let usage = apiService.consumeCapturedUsage(for: requestID)
+                if let usage, !usage.isEmpty {
+                    Task { @MainActor in
+                        UsageTrackingService.shared.record(
+                            usage: usage,
+                            providerName: apiService.name,
+                            modelId: apiService.model,
+                            chatID: chatID
+                        )
+                    }
+                }
+            }
             completion(result.mapError { $0 as Error })
         }
     }

--- a/Warden/Utilities/ChatService.swift
+++ b/Warden/Utilities/ChatService.swift
@@ -37,21 +37,20 @@ class ChatService {
     ) {
         let requestID = apiService.beginUsageCapture()
         apiService.sendMessage(messages, tools: tools, settings: settings) { [weak self] result in
-            // Record token usage captured by the handler for this non-streaming
-            // completion (best effort — usage accounting must never break a chat).
-            // Only the main chat path passes a chatID; auxiliary calls (chat-name
-            // generation, connection tests) leave it nil and are not tracked.
-            if let self, let chatID {
-                let usage = apiService.consumeCapturedUsage(for: requestID)
-                if let usage, !usage.isEmpty {
-                    Task { @MainActor in
-                        UsageTrackingService.shared.record(
-                            usage: usage,
-                            providerName: apiService.name,
-                            modelId: apiService.model,
-                            chatID: chatID
-                        )
-                    }
+            // Close the capture scope on every exit path so captured usage never
+            // lingers on the handler. Only main-chat completions (chatID passed)
+            // are recorded; auxiliary calls (chat-name generation, connection
+            // tests) have their partial usage discarded. Best effort — usage
+            // accounting must never break a chat.
+            let usage = apiService.consumeCapturedUsage(for: requestID)
+            if let self, let chatID, let usage, !usage.isEmpty {
+                Task { @MainActor in
+                    UsageTrackingService.shared.record(
+                        usage: usage,
+                        providerName: apiService.name,
+                        modelId: apiService.model,
+                        chatID: chatID
+                    )
                 }
             }
             completion(result.mapError { $0 as Error })

--- a/Warden/Utilities/MessageManager.swift
+++ b/Warden/Utilities/MessageManager.swift
@@ -289,7 +289,8 @@ final class MessageManager: ObservableObject {
                 apiService: apiService,
                 messages: requestMessages,
                 tools: toolDefinitions.isEmpty ? nil : toolDefinitions,
-                settings: GenerationSettings(temperature: temperature, reasoningEffort: chat.reasoningEffort)
+                settings: GenerationSettings(temperature: temperature, reasoningEffort: chat.reasoningEffort),
+                chatID: chat.id
             ) { [weak self] result in
                 guard let self = self else { return }
 
@@ -702,7 +703,8 @@ final class MessageManager: ObservableObject {
             apiService: apiService,
             messages: requestMessages,
             tools: nil, // Don't provide tools again to avoid loops
-            settings: GenerationSettings(temperature: temperature, reasoningEffort: chat.reasoningEffort)
+            settings: GenerationSettings(temperature: temperature, reasoningEffort: chat.reasoningEffort),
+            chatID: chat.id
         ) { [weak self] result in
             guard let self = self else { return }
             

--- a/Warden/Utilities/MessageManager.swift
+++ b/Warden/Utilities/MessageManager.swift
@@ -457,7 +457,8 @@ final class MessageManager: ObservableObject {
                     apiService: apiService,
                     messages: requestMessages,
                     tools: toolDefinitions.isEmpty ? nil : toolDefinitions,
-                    settings: GenerationSettings(temperature: temperature, reasoningEffort: chat.reasoningEffort)
+                    settings: GenerationSettings(temperature: temperature, reasoningEffort: chat.reasoningEffort),
+                    chatID: chat.id
                 ) { chunk in
                     chunkCount += 1
                     guard !chunk.isEmpty else { return }

--- a/Warden/Utilities/PromptLibraryManager.swift
+++ b/Warden/Utilities/PromptLibraryManager.swift
@@ -15,6 +15,12 @@ final class PromptLibraryManager {
         addPresetsIfNeeded()
     }
 
+    /// Forces the singleton (and first-run preset seeding) to initialize at app
+    /// startup, so starter prompts exist even if no composer is ever opened.
+    static func warmUp() {
+        _ = shared
+    }
+
     // MARK: - CRUD
 
     @discardableResult
@@ -167,14 +173,21 @@ final class PromptLibraryManager {
         return value
     }
 
-    private func save() {
-        guard viewContext.hasChanges else { return }
+    /// Persists pending changes. On failure the failed mutations are rolled back
+    /// (rather than left dangling in the context) and `false` is returned so
+    /// callers can't assume an operation persisted when it didn't.
+    @discardableResult
+    private func save() -> Bool {
+        guard viewContext.hasChanges else { return true }
         do {
             try viewContext.save()
+            return true
         } catch {
+            viewContext.rollback()
             WardenLog.app.error(
                 "[Prompts] Save failed: \(error.localizedDescription, privacy: .public)"
             )
+            return false
         }
     }
 }

--- a/Warden/Utilities/PromptLibraryManager.swift
+++ b/Warden/Utilities/PromptLibraryManager.swift
@@ -1,0 +1,180 @@
+import CoreData
+import Foundation
+import os
+
+/// Manages the user's prompt library: CRUD, usage accounting, and first-run presets.
+@MainActor
+final class PromptLibraryManager {
+    static let shared = PromptLibraryManager()
+
+    private let viewContext: NSManagedObjectContext
+    private static let presetsAddedKey = "promptLibraryPresetsAdded"
+
+    init(viewContext: NSManagedObjectContext = PersistenceController.shared.container.viewContext) {
+        self.viewContext = viewContext
+        addPresetsIfNeeded()
+    }
+
+    // MARK: - CRUD
+
+    @discardableResult
+    func addPrompt(
+        name: String,
+        content: String,
+        shortcut: String? = nil,
+        category: String? = nil
+    ) -> PromptEntity {
+        let prompt = PromptEntity(context: viewContext)
+        prompt.id = UUID()
+        prompt.name = name
+        prompt.content = content
+        prompt.shortcut = normalizedShortcut(shortcut)
+        prompt.category = category?.isEmpty == true ? nil : category
+        prompt.createdDate = Date()
+        save()
+        return prompt
+    }
+
+    func delete(_ prompt: PromptEntity) {
+        viewContext.delete(prompt)
+        save()
+    }
+
+    func duplicate(_ prompt: PromptEntity) -> PromptEntity {
+        let copy = addPrompt(
+            name: (prompt.name ?? "Prompt") + " Copy",
+            content: prompt.content ?? "",
+            shortcut: nil,
+            category: prompt.category
+        )
+        return copy
+    }
+
+    /// Bumps usage stats when a prompt is inserted into a message.
+    func recordUse(_ prompt: PromptEntity) {
+        prompt.usageCount += 1
+        prompt.lastUsedDate = Date()
+        save()
+    }
+
+    /// All prompts matching a slash-command query, e.g. query "exp" matches "/explain".
+    /// Sorted by usage count (most used first) so autocomplete ranks favorites.
+    func prompts(matchingQuery query: String?) -> [PromptEntity] {
+        let request = NSFetchRequest<PromptEntity>(entityName: "PromptEntity")
+        if let query = query?.trimmingCharacters(in: .whitespacesAndNewlines), !query.isEmpty {
+            request.predicate = NSPredicate(
+                format: "name CONTAINS[cd] %@ OR shortcut CONTAINS[cd] %@",
+                query, query
+            )
+        }
+        request.sortDescriptors = [
+            NSSortDescriptor(key: "usageCount", ascending: false),
+            NSSortDescriptor(key: "name", ascending: true),
+        ]
+        request.fetchLimit = 20
+
+        do {
+            return try viewContext.fetch(request)
+        } catch {
+            WardenLog.app.error(
+                "[Prompts] Failed to fetch prompts: \(error.localizedDescription, privacy: .public)"
+            )
+            return []
+        }
+    }
+
+    func promptCount() -> Int {
+        let request = NSFetchRequest<PromptEntity>(entityName: "PromptEntity")
+        return (try? viewContext.count(for: request)) ?? 0
+    }
+
+    // MARK: - Presets
+
+    struct Preset {
+        let name: String
+        let shortcut: String
+        let content: String
+        let category: String
+    }
+
+    static let defaultPresets: [Preset] = [
+        Preset(
+            name: "Explain This",
+            shortcut: "explain",
+            content: "Explain the following in simple terms. Define any jargon, use an analogy where helpful, and end with the single most important takeaway.\n\n{{text}}",
+            category: "General"
+        ),
+        Preset(
+            name: "Summarize",
+            shortcut: "summarize",
+            content: "Summarize the text below. Provide: 1) A one-sentence TL;DR, 2) Three to five key points as bullets. Keep it under 150 words.\n\n{{text}}",
+            category: "Writing"
+        ),
+        Preset(
+            name: "Proofread",
+            shortcut: "proofread",
+            content: "Proofread the following text. Fix grammar, spelling, and clarity issues without changing my voice or meaning. Return only the corrected text.\n\n{{text}}",
+            category: "Writing"
+        ),
+        Preset(
+            name: "Code Review",
+            shortcut: "review",
+            content: "Review this code for bugs, edge cases, performance issues, and readability. Be specific — point to exact lines and suggest concrete fixes. Do not rewrite working code unnecessarily.\n\n```\n{{text}}\n```",
+            category: "Engineering"
+        ),
+        Preset(
+            name: "Translate",
+            shortcut: "translate",
+            content: "Translate the following into natural, idiomatic English. Preserve tone and formatting. If any term is ambiguous, list alternatives in brackets.\n\n{{text}}",
+            category: "General"
+        ),
+    ]
+
+    private func addPresetsIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: Self.presetsAddedKey) else { return }
+
+        for preset in Self.defaultPresets {
+            let prompt = PromptEntity(context: viewContext)
+            prompt.id = UUID()
+            prompt.name = preset.name
+            prompt.content = preset.content
+            prompt.shortcut = preset.shortcut
+            prompt.category = preset.category
+            prompt.createdDate = Date()
+        }
+
+        do {
+            try viewContext.save()
+            defaults.set(true, forKey: Self.presetsAddedKey)
+            #if DEBUG
+            WardenLog.app.debug("[Prompts] Seeded \(Self.defaultPresets.count, privacy: .public) starter prompts")
+            #endif
+        } catch {
+            viewContext.rollback()
+            WardenLog.app.error(
+                "[Prompts] Failed to seed presets: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func normalizedShortcut(_ shortcut: String?) -> String? {
+        guard var value = shortcut?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !value.isEmpty else { return nil }
+        if value.hasPrefix("/") { value.removeFirst() }
+        return value
+    }
+
+    private func save() {
+        guard viewContext.hasChanges else { return }
+        do {
+            try viewContext.save()
+        } catch {
+            WardenLog.app.error(
+                "[Prompts] Save failed: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+}

--- a/Warden/Utilities/UsageTrackingService.swift
+++ b/Warden/Utilities/UsageTrackingService.swift
@@ -1,0 +1,298 @@
+import CoreData
+import Foundation
+import os
+
+/// Token usage reported by a provider for a single completion.
+struct TokenUsage: Codable, Equatable {
+    var inputTokens: Int
+    var outputTokens: Int
+    var cachedInputTokens: Int = 0
+    var reasoningTokens: Int = 0
+
+    var isEmpty: Bool { inputTokens <= 0 && outputTokens <= 0 }
+
+    /// Merges two partial reports (e.g. Anthropic splits input/output across events).
+    /// Later values win when greater than zero.
+    static func merged(_ newer: TokenUsage, into older: TokenUsage?) -> TokenUsage {
+        guard let older else { return newer }
+        var result = older
+        if newer.inputTokens > 0 { result.inputTokens = newer.inputTokens }
+        if newer.outputTokens > older.outputTokens { result.outputTokens = newer.outputTokens }
+        if newer.cachedInputTokens > 0 { result.cachedInputTokens = newer.cachedInputTokens }
+        if newer.reasoningTokens > older.reasoningTokens { result.reasoningTokens = newer.reasoningTokens }
+        return result
+    }
+}
+
+/// Extracts token usage from OpenAI-compatible and Anthropic response payloads.
+///
+/// Both streaming chunks (`usage` on the final chunk) and non-streaming bodies carry
+/// the same top-level shape, so one extractor serves both paths.
+enum UsageExtractor {
+    /// Extracts usage from an OpenAI-compatible JSON dictionary (`usage.prompt_tokens` / `completion_tokens`).
+    static func fromOpenAIDictionary(_ dict: [String: Any]) -> TokenUsage? {
+        guard let usage = dict["usage"] as? [String: Any] else { return nil }
+
+        // Responses API style names first, then chat-completions names.
+        let input = (usage["input_tokens"] as? NSNumber)?.intValue
+            ?? (usage["prompt_tokens"] as? NSNumber)?.intValue ?? 0
+        let output = (usage["output_tokens"] as? NSNumber)?.intValue
+            ?? (usage["completion_tokens"] as? NSNumber)?.intValue ?? 0
+
+        guard input > 0 || output > 0 else { return nil }
+
+        var result = TokenUsage(inputTokens: input, outputTokens: output)
+
+        if let details = usage["prompt_tokens_details"] as? [String: Any] {
+            result.cachedInputTokens = (details["cached_tokens"] as? NSNumber)?.intValue ?? 0
+        } else if let details = usage["input_tokens_details"] as? [String: Any] {
+            result.cachedInputTokens = (details["cached_tokens"] as? NSNumber)?.intValue ?? 0
+        }
+
+        if let details = usage["completion_tokens_details"] as? [String: Any] {
+            result.reasoningTokens = (details["reasoning_tokens"] as? NSNumber)?.intValue ?? 0
+        } else if let details = usage["output_tokens_details"] as? [String: Any] {
+            result.reasoningTokens = (details["reasoning_tokens"] as? NSNumber)?.intValue ?? 0
+        }
+
+        return result
+    }
+
+    /// Extracts usage from an Anthropic `message_start` / `message_delta` event dictionary
+    /// (`message.usage.input_tokens` / `usage.output_tokens`).
+    static func fromAnthropicDictionary(_ dict: [String: Any]) -> TokenUsage? {
+        let containers: [[String: Any]] = [
+            dict["message"] as? [String: Any],
+            dict["usage"] as? [String: Any],
+        ]
+        .compactMap { $0 }
+
+        for container in containers {
+            guard let usage = container["usage"] as? [String: Any] else { continue }
+            let input = (usage["input_tokens"] as? NSNumber)?.intValue ?? 0
+            let output = (usage["output_tokens"] as? NSNumber)?.intValue ?? 0
+            guard input > 0 || output > 0 else { continue }
+
+            var result = TokenUsage(inputTokens: input, outputTokens: output)
+            result.cachedInputTokens = (usage["cache_read_input_tokens"] as? NSNumber)?.intValue ?? 0
+            if let outputDelta = usage["output_tokens"] as? NSNumber,
+               let deltaReasoning = usage["reasoning_output_tokens"] as? NSNumber {
+                result.reasoningTokens = deltaReasoning.intValue
+            }
+            return result
+        }
+        return nil
+    }
+
+    /// Extracts usage from an Ollama final chunk (`prompt_eval_count` / `eval_count`).
+    static func fromOllamaDictionary(_ dict: [String: Any]) -> TokenUsage? {
+        guard let promptEval = dict["prompt_eval_count"] as? NSNumber,
+              let eval = dict["eval_count"] as? NSNumber else {
+            return nil
+        }
+        return TokenUsage(inputTokens: promptEval.intValue, outputTokens: eval.intValue)
+    }
+
+    /// Provider-agnostic entry point: tries OpenAI-compatible, Anthropic, then Ollama shapes.
+    static func extract(from dict: [String: Any]) -> TokenUsage? {
+        fromOpenAIDictionary(dict) ?? fromAnthropicDictionary(dict) ?? fromOllamaDictionary(dict)
+    }
+
+    /// Extracts usage from raw SSE event data (streaming path).
+    static func extract(fromStreamData data: Data?) -> TokenUsage? {
+        guard let data,
+              let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+            return nil
+        }
+        return extract(from: json)
+    }
+}
+
+/// Calculates estimated USD cost for token usage using Warden's model metadata pricing.
+enum UsageCostCalculator {
+    struct CostResult {
+        let costUSD: Double
+        let source: String
+    }
+
+    static func cost(
+        for usage: TokenUsage,
+        providerName: String,
+        modelId: String
+    ) -> CostResult {
+        let provider = ProviderID(normalizing: providerName)?.rawValue ?? providerName.lowercased()
+
+        guard let metadata = ModelMetadataStorage.getMetadata(provider: provider, modelId: modelId),
+              let pricing = metadata.pricing else {
+            return CostResult(costUSD: 0, source: "unpriced")
+        }
+
+        let inputPerToken = (pricing.inputPer1M ?? 0) / 1_000_000
+        let outputPerToken = (pricing.outputPer1M ?? 0) / 1_000_000
+
+        // Cached input is typically billed at a steep discount; use a 50% factor when
+        // the provider metadata doesn't distinguish it (conservative middle ground).
+        let billableInput = max(0, usage.inputTokens - usage.cachedInputTokens)
+        let cachedCost = Double(usage.cachedInputTokens) * inputPerToken * 0.5
+        let reasoningCost = Double(usage.reasoningTokens) * outputPerToken
+
+        let cost = Double(billableInput) * inputPerToken
+            + cachedCost
+            + (Double(usage.outputTokens) * outputPerToken)
+            + reasoningCost
+
+        let source: String
+        if metadata.isStale {
+            source = "cached-stale"
+        } else {
+            source = pricing.source
+        }
+        return CostResult(costUSD: cost, source: source)
+    }
+}
+
+/// Records and aggregates per-completion usage records.
+@MainActor
+final class UsageTrackingService {
+    static let shared = UsageTrackingService()
+
+    private let viewContext: NSManagedObjectContext
+
+    init(viewContext: NSManagedObjectContext = PersistenceController.shared.container.viewContext) {
+        self.viewContext = viewContext
+    }
+
+    /// Records one completion's usage. No-ops when the provider reported no usage.
+    func record(
+        usage: TokenUsage,
+        providerName: String,
+        modelId: String,
+        chatID: UUID?
+    ) {
+        guard !usage.isEmpty else { return }
+
+        let cost = UsageCostCalculator.cost(for: usage, providerName: providerName, modelId: modelId)
+
+        let record = UsageRecordEntity(context: viewContext)
+        record.id = UUID()
+        record.date = Date()
+        record.providerName = providerName
+        record.modelId = modelId
+        record.chatID = chatID
+        record.inputTokens = Int64(usage.inputTokens)
+        record.outputTokens = Int64(usage.outputTokens)
+        record.cachedInputTokens = Int64(usage.cachedInputTokens)
+        record.reasoningTokens = Int64(usage.reasoningTokens)
+        record.estimatedCostUSD = cost.costUSD
+        record.pricingSource = cost.source
+
+        do {
+            try viewContext.save()
+            #if DEBUG
+            WardenLog.app.debug(
+                "[Usage] Recorded \(usage.inputTokens, privacy: .public) in / \(usage.outputTokens, privacy: .public) out tokens (~$\(String(format: "%.4f", cost.costUSD), privacy: .public)) for \(modelId, privacy: .public)"
+            )
+            #endif
+        } catch {
+            // Never let usage accounting break a chat — log and continue.
+            viewContext.rollback()
+            WardenLog.app.error(
+                "[Usage] Failed to save usage record: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: - Aggregation
+
+    struct Totals {
+        var inputTokens: Int64 = 0
+        var outputTokens: Int64 = 0
+        var costUSD: Double = 0
+        var requestCount: Int = 0
+    }
+
+    struct ModelBreakdown: Identifiable {
+        let id: String
+        let providerName: String
+        var totals: Totals
+    }
+
+    /// Aggregates records within a date range (nil = all time).
+    func totals(from: Date? = nil, to: Date? = nil) -> Totals {
+        var result = Totals()
+        for record in fetchRecords(from: from, to: to) {
+            result.inputTokens += record.inputTokens
+            result.outputTokens += record.outputTokens
+            result.costUSD += record.estimatedCostUSD
+            result.requestCount += 1
+        }
+        return result
+    }
+
+    func breakdownByModel(from: Date? = nil, to: Date? = nil) -> [ModelBreakdown] {
+        var grouped: [String: ModelBreakdown] = [:]
+        for record in fetchRecords(from: from, to: to) {
+            let key = "\(record.providerName ?? "unknown")/\(record.modelId ?? "unknown")"
+            var entry = grouped[key] ?? ModelBreakdown(
+                id: key,
+                providerName: record.providerName ?? "Unknown",
+                totals: Totals()
+            )
+            entry.totals.inputTokens += record.inputTokens
+            entry.totals.outputTokens += record.outputTokens
+            entry.totals.costUSD += record.estimatedCostUSD
+            entry.totals.requestCount += 1
+            grouped[key] = entry
+        }
+        return grouped.values.sorted { $0.totals.costUSD > $1.totals.costUSD }
+    }
+
+    /// Daily totals for the trailing `days` days, oldest first (for charts/sparklines).
+    func dailyTotals(days: Int) -> [(date: Date, totals: Totals)] {
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: Date())
+        guard let windowStart = calendar.date(byAdding: .day, value: -(days - 1), to: startOfToday) else {
+            return []
+        }
+
+        var buckets: [Date: Totals] = [:]
+        for offset in 0..<days {
+            if let day = calendar.date(byAdding: .day, value: offset, to: startOfToday) {
+                buckets[day] = Totals()
+            }
+        }
+
+        for record in fetchRecords(from: windowStart) {
+            guard let date = record.date else { continue }
+            let day = calendar.startOfDay(for: date)
+            var totals = buckets[day] ?? Totals()
+            totals.inputTokens += record.inputTokens
+            totals.outputTokens += record.outputTokens
+            totals.costUSD += record.estimatedCostUSD
+            totals.requestCount += 1
+            buckets[day] = totals
+        }
+
+        return buckets.keys.sorted().map { ($0, buckets[$0]!) }
+    }
+
+    private func fetchRecords(from: Date?, to: Date? = nil) -> [UsageRecordEntity] {
+        let request = UsageRecordEntity.fetchRequest()
+        var predicates: [NSPredicate] = []
+        if let from { predicates.append(NSPredicate(format: "date >= %@", from as NSDate)) }
+        if let to { predicates.append(NSPredicate(format: "date <= %@", to as NSDate)) }
+        if !predicates.isEmpty {
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+        }
+        request.fetchBatchSize = 200
+
+        do {
+            return try viewContext.fetch(request)
+        } catch {
+            WardenLog.app.error(
+                "[Usage] Failed to fetch usage records: \(error.localizedDescription, privacy: .public)"
+            )
+            return []
+        }
+    }
+}

--- a/Warden/Utilities/UsageTrackingService.swift
+++ b/Warden/Utilities/UsageTrackingService.swift
@@ -31,31 +31,48 @@ struct TokenUsage: Codable, Equatable {
 enum UsageExtractor {
     /// Extracts usage from an OpenAI-compatible JSON dictionary (`usage.prompt_tokens` / `completion_tokens`).
     static func fromOpenAIDictionary(_ dict: [String: Any]) -> TokenUsage? {
-        guard let usage = dict["usage"] as? [String: Any] else { return nil }
-
-        // Responses API style names first, then chat-completions names.
-        let input = (usage["input_tokens"] as? NSNumber)?.intValue
-            ?? (usage["prompt_tokens"] as? NSNumber)?.intValue ?? 0
-        let output = (usage["output_tokens"] as? NSNumber)?.intValue
-            ?? (usage["completion_tokens"] as? NSNumber)?.intValue ?? 0
-
-        guard input > 0 || output > 0 else { return nil }
-
-        var result = TokenUsage(inputTokens: input, outputTokens: output)
-
-        if let details = usage["prompt_tokens_details"] as? [String: Any] {
-            result.cachedInputTokens = (details["cached_tokens"] as? NSNumber)?.intValue ?? 0
-        } else if let details = usage["input_tokens_details"] as? [String: Any] {
-            result.cachedInputTokens = (details["cached_tokens"] as? NSNumber)?.intValue ?? 0
+        // Chat-completions bodies carry `usage` at top level; Responses-API stream
+        // events nest it under `response` (e.g. `response.completed`).
+        var containers: [[String: Any]] = [dict]
+        if let response = dict["response"] as? [String: Any] {
+            containers.append(response)
         }
 
-        if let details = usage["completion_tokens_details"] as? [String: Any] {
-            result.reasoningTokens = (details["reasoning_tokens"] as? NSNumber)?.intValue ?? 0
-        } else if let details = usage["output_tokens_details"] as? [String: Any] {
-            result.reasoningTokens = (details["reasoning_tokens"] as? NSNumber)?.intValue ?? 0
-        }
+        for container in containers {
+            guard let usage = container["usage"] as? [String: Any] else { continue }
+            // Anthropic payloads also expose a top-level `usage`, but with
+            // provider-specific keys the OpenAI parser would drop (cached input).
+            // Defer to the Anthropic parser when those keys are present.
+            guard usage["cache_read_input_tokens"] == nil,
+                  usage["cache_creation_input_tokens"] == nil else {
+                return nil
+            }
 
-        return result
+            // Responses API style names first, then chat-completions names.
+            let input = (usage["input_tokens"] as? NSNumber)?.intValue
+                ?? (usage["prompt_tokens"] as? NSNumber)?.intValue ?? 0
+            let output = (usage["output_tokens"] as? NSNumber)?.intValue
+                ?? (usage["completion_tokens"] as? NSNumber)?.intValue ?? 0
+
+            guard input > 0 || output > 0 else { continue }
+
+            var result = TokenUsage(inputTokens: input, outputTokens: output)
+
+            if let details = usage["prompt_tokens_details"] as? [String: Any] {
+                result.cachedInputTokens = (details["cached_tokens"] as? NSNumber)?.intValue ?? 0
+            } else if let details = usage["input_tokens_details"] as? [String: Any] {
+                result.cachedInputTokens = (details["cached_tokens"] as? NSNumber)?.intValue ?? 0
+            }
+
+            if let details = usage["completion_tokens_details"] as? [String: Any] {
+                result.reasoningTokens = (details["reasoning_tokens"] as? NSNumber)?.intValue ?? 0
+            } else if let details = usage["output_tokens_details"] as? [String: Any] {
+                result.reasoningTokens = (details["reasoning_tokens"] as? NSNumber)?.intValue ?? 0
+            }
+
+            return result
+        }
+        return nil
     }
 
     /// Extracts usage from an Anthropic `message_start` / `message_delta` event dictionary
@@ -75,8 +92,7 @@ enum UsageExtractor {
 
             var result = TokenUsage(inputTokens: input, outputTokens: output)
             result.cachedInputTokens = (usage["cache_read_input_tokens"] as? NSNumber)?.intValue ?? 0
-            if let outputDelta = usage["output_tokens"] as? NSNumber,
-               let deltaReasoning = usage["reasoning_output_tokens"] as? NSNumber {
+            if let deltaReasoning = usage["reasoning_output_tokens"] as? NSNumber {
                 result.reasoningTokens = deltaReasoning.intValue
             }
             return result
@@ -93,9 +109,11 @@ enum UsageExtractor {
         return TokenUsage(inputTokens: promptEval.intValue, outputTokens: eval.intValue)
     }
 
-    /// Provider-agnostic entry point: tries OpenAI-compatible, Anthropic, then Ollama shapes.
+    /// Provider-agnostic entry point: tries Anthropic, OpenAI-compatible, then Ollama shapes.
+    /// Anthropic first: its payloads also expose a top-level `usage` that would otherwise
+    /// be mis-parsed by the OpenAI path and lose cached-input token counts.
     static func extract(from dict: [String: Any]) -> TokenUsage? {
-        fromOpenAIDictionary(dict) ?? fromAnthropicDictionary(dict) ?? fromOllamaDictionary(dict)
+        fromAnthropicDictionary(dict) ?? fromOpenAIDictionary(dict) ?? fromOllamaDictionary(dict)
     }
 
     /// Extracts usage from raw SSE event data (streaming path).
@@ -134,12 +152,11 @@ enum UsageCostCalculator {
         // the provider metadata doesn't distinguish it (conservative middle ground).
         let billableInput = max(0, usage.inputTokens - usage.cachedInputTokens)
         let cachedCost = Double(usage.cachedInputTokens) * inputPerToken * 0.5
-        let reasoningCost = Double(usage.reasoningTokens) * outputPerToken
 
+        // outputTokens already includes reasoning tokens, so charge total output once.
         let cost = Double(billableInput) * inputPerToken
             + cachedCost
             + (Double(usage.outputTokens) * outputPerToken)
-            + reasoningCost
 
         let source: String
         if metadata.isStale {
@@ -163,6 +180,9 @@ final class UsageTrackingService {
     }
 
     /// Records one completion's usage. No-ops when the provider reported no usage.
+    ///
+    /// Writes on a dedicated background context so a failed save can never discard
+    /// unsaved changes sitting in the shared view context (chat edits, etc.).
     func record(
         usage: TokenUsage,
         providerName: String,
@@ -172,33 +192,36 @@ final class UsageTrackingService {
         guard !usage.isEmpty else { return }
 
         let cost = UsageCostCalculator.cost(for: usage, providerName: providerName, modelId: modelId)
+        let context = PersistenceController.shared.container.newBackgroundContext()
 
-        let record = UsageRecordEntity(context: viewContext)
-        record.id = UUID()
-        record.date = Date()
-        record.providerName = providerName
-        record.modelId = modelId
-        record.chatID = chatID
-        record.inputTokens = Int64(usage.inputTokens)
-        record.outputTokens = Int64(usage.outputTokens)
-        record.cachedInputTokens = Int64(usage.cachedInputTokens)
-        record.reasoningTokens = Int64(usage.reasoningTokens)
-        record.estimatedCostUSD = cost.costUSD
-        record.pricingSource = cost.source
+        context.perform {
+            let record = UsageRecordEntity(context: context)
+            record.id = UUID()
+            record.date = Date()
+            record.providerName = providerName
+            record.modelId = modelId
+            record.chatID = chatID
+            record.inputTokens = Int64(usage.inputTokens)
+            record.outputTokens = Int64(usage.outputTokens)
+            record.cachedInputTokens = Int64(usage.cachedInputTokens)
+            record.reasoningTokens = Int64(usage.reasoningTokens)
+            record.estimatedCostUSD = cost.costUSD
+            record.pricingSource = cost.source
 
-        do {
-            try viewContext.save()
-            #if DEBUG
-            WardenLog.app.debug(
-                "[Usage] Recorded \(usage.inputTokens, privacy: .public) in / \(usage.outputTokens, privacy: .public) out tokens (~$\(String(format: "%.4f", cost.costUSD), privacy: .public)) for \(modelId, privacy: .public)"
-            )
-            #endif
-        } catch {
-            // Never let usage accounting break a chat — log and continue.
-            viewContext.rollback()
-            WardenLog.app.error(
-                "[Usage] Failed to save usage record: \(error.localizedDescription, privacy: .public)"
-            )
+            do {
+                try context.save()
+                #if DEBUG
+                WardenLog.app.debug(
+                    "[Usage] Recorded \(usage.inputTokens, privacy: .public) in / \(usage.outputTokens, privacy: .public) out tokens (~$\(String(format: "%.4f", cost.costUSD), privacy: .public)) for \(modelId, privacy: .public)"
+                )
+                #endif
+            } catch {
+                // Never let usage accounting break a chat — log and continue.
+                context.rollback()
+                WardenLog.app.error(
+                    "[Usage] Failed to save usage record: \(error.localizedDescription, privacy: .public)"
+                )
+            }
         }
     }
 
@@ -213,6 +236,7 @@ final class UsageTrackingService {
 
     struct ModelBreakdown: Identifiable {
         let id: String
+        let modelId: String
         let providerName: String
         var totals: Totals
     }
@@ -232,10 +256,13 @@ final class UsageTrackingService {
     func breakdownByModel(from: Date? = nil, to: Date? = nil) -> [ModelBreakdown] {
         var grouped: [String: ModelBreakdown] = [:]
         for record in fetchRecords(from: from, to: to) {
-            let key = "\(record.providerName ?? "unknown")/\(record.modelId ?? "unknown")"
+            let provider = record.providerName ?? "Unknown"
+            let modelId = record.modelId ?? "unknown"
+            let key = "\(provider)/\(modelId)"
             var entry = grouped[key] ?? ModelBreakdown(
                 id: key,
-                providerName: record.providerName ?? "Unknown",
+                modelId: modelId,
+                providerName: provider,
                 totals: Totals()
             )
             entry.totals.inputTokens += record.inputTokens
@@ -257,7 +284,7 @@ final class UsageTrackingService {
 
         var buckets: [Date: Totals] = [:]
         for offset in 0..<days {
-            if let day = calendar.date(byAdding: .day, value: offset, to: startOfToday) {
+            if let day = calendar.date(byAdding: .day, value: offset, to: windowStart) {
                 buckets[day] = Totals()
             }
         }
@@ -265,7 +292,8 @@ final class UsageTrackingService {
         for record in fetchRecords(from: windowStart) {
             guard let date = record.date else { continue }
             let day = calendar.startOfDay(for: date)
-            var totals = buckets[day] ?? Totals()
+            guard buckets[day] != nil else { continue } // Skip records outside the requested window
+            var totals = buckets[day]!
             totals.inputTokens += record.inputTokens
             totals.outputTokens += record.outputTokens
             totals.costUSD += record.estimatedCostUSD

--- a/Warden/WardenApp.swift
+++ b/Warden/WardenApp.swift
@@ -116,6 +116,11 @@ struct WardenApp: App {
         DatabasePatcher.applyPatches(context: persistenceController.container.viewContext)
         DatabasePatcher.migrateExistingConfiguration(context: persistenceController.container.viewContext)
 
+        // Seed the prompt library's starter prompts on first launch
+        Task { @MainActor in
+            PromptLibraryManager.warmUp()
+        }
+
         // Initialize automatic updates
         _ = UpdaterManager.shared
     }


### PR DESCRIPTION
## Summary

Two new features, built end-to-end:

### 📚 Prompt Library
- **Slash-command autocomplete** — type `/` in any chat composer to get a floating suggestion list of saved prompts, ranked by most-used. ↑↓ navigate, Enter accepts, Esc dismisses; click/hover also work. Arrows are only intercepted while completion is active, so normal cursor movement is untouched.
- **`{{text}}` placeholders** — prompts can include a placeholder that stays in the message for the user to fill (or paste selection into later).
- **Prompt Library tab in Preferences** — list with usage counts, add/edit sheet, delete with confirmation.
- **5 seeded starter prompts** on first launch: Explain This, Summarize, Proofread, Code Review, Translate.

### 💸 Usage & Cost Tracking
- **Token capture on every completion** — `UsageExtractor` parses usage from OpenAI-compatible (`prompt_tokens` + Responses-API `input_tokens`), Anthropic (`message.usage`, with partial-report merging across events), and Ollama (`eval_count`) response shapes, on both streaming and non-streaming paths.
- **Cost estimation from existing metadata** — reuses `ModelMetadataStorage` pricing data (the same source powering model tooltips). Cached input billed at 0.5×, reasoning tokens as output; records tagged with pricing source including a stale-cache flag.
- **Usage tab in Preferences** — 7d/30d/all-time window picker, spend/tokens/requests summary cards, daily cost bar chart (Swift Charts), and per-model breakdown sorted by spend.
- **Fail-safe by design** — usage accounting is best-effort: a failed save rolls back and logs, never breaks a chat. Capture is lock-guarded since handlers are used from concurrent tasks.

## Changes

| Area | Files |
|---|---|
| Core Data | `wardenDataModel` (+`PromptEntity`, `UsageRecordEntity` — purely additive, lightweight migration), `Models.swift` |
| Services | `UsageTrackingService.swift`, `PromptLibraryManager.swift` (new) |
| API layer | `BaseAPIHandler.swift`, `APIProtocol.swift`, `APIServiceManager.swift`, `ChatService.swift`, `MessageManager.swift` |
| Composer UI | `SubmitTextEditor.swift`, `MessageInputView.swift`, `PromptCompletionView.swift` (new) |
| Preferences | `PreferencesView.swift`, `TabPromptLibraryView.swift` (new), `TabUsageView.swift` (new) |

## Test plan

- [ ] Launch app → Prompt Library tab shows 5 starter prompts; Usage tab renders empty states
- [ ] In a chat, type `/sum` → suggestion appears; Enter inserts the Summarize prompt and bumps its use count
- [ ] ↑↓ + Esc navigation works while the list is open; arrows still move the cursor normally when closed
- [ ] Add/edit/delete a prompt via Preferences → reflected immediately in composer suggestions
- [ ] Send messages against OpenAI/Anthropic/Ollama services → Usage tab records tokens and estimated cost per model
- [ ] Existing chats unaffected after automatic lightweight Core Data migration
- [ ] Cancel a stream mid-flight → no partial/duplicate usage records

## Summary by Sourcery

Add prompt management and completion usage analytics with cost estimation across supported providers.

New Features:
- Add a prompt library with seeded starter prompts, slash-command autocomplete, usage-ranked suggestions, and placeholder support.
- Add Preferences views for creating, editing, deleting, and monitoring prompt usage.
- Add usage and cost tracking for completions across OpenAI-compatible, Anthropic, and Ollama providers.
- Add a Usage dashboard with time-windowed totals, daily cost charts, and per-model breakdowns.

Bug Fixes:
- Prevent partial or duplicate usage records when streams are cancelled or fail.
- Keep usage tracking failures isolated from chat delivery.

Enhancements:
- Extend completion handling to capture and merge token usage from streaming and non-streaming responses, including cached and reasoning tokens.
- Estimate completion costs from model pricing metadata and retain pricing provenance.
- Add lightweight Core Data storage for prompts and usage records with automatic migration.
- Preserve normal editor keyboard behavior when prompt completion is inactive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Prompt Library with slash-command autocomplete and a Usage & Cost tracker. Previously the composer had no prompt insertion and we didn’t record tokens/costs; now typing “/” inserts saved prompts and we persist per-completion usage and estimated spend across OpenAI/Anthropic/Ollama without affecting message delivery.

- Core Data: adds `PromptEntity` and `UsageRecordEntity`; versions the model for a lightweight migration; seeds 5 starter prompts at app startup; drops the duplicate class codegen so the project builds.
- Composer/editor: "/" suggestions via `PromptCompletionState` and `SubmitTextEditor`; arrows/Enter/Esc are intercepted only while the list is visible; suggestions sync on appear; normal cursor movement remains unchanged.
- API/usage capture: request-scoped capture in `BaseAPIHandler` for streaming and non-streaming; `ChatService`/`MessageManager` pass chatID; usage is discarded on cancel/error and for auxiliary calls without a chatID; default no-op usage methods added to `APIService`.
- Usage extraction: supports Responses-API nested usage, Anthropic-first parsing to keep cached-input counts, and Ollama eval counts; cheap checks avoid parsing every SSE chunk; non-streaming bodies are captured too.
- Costing: derives prices from `ModelMetadataStorage`; cached input billed at 0.5×; reasoning tokens counted once; records pricing source and a stale-cache flag.
- Preferences: adds Prompt Library and Usage tabs; library supports add/edit/delete; usage shows 7d/30d/all-time totals, a daily cost chart, and per-model breakdown with live refresh and locale-aware formatting.

**Rollout and verification**
- No action required: migration runs automatically and does not modify existing entities or chats.
- Verify usage recording for OpenAI/Anthropic/Ollama on both streaming and non-streaming paths; canceling a stream does not create partial or duplicate records.

<sup>Written for commit da2e31dd1f44a0a60896e36f7feb03b07b6b7f66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/WardenApp/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prompt library for creating, editing, organizing, searching, and reusing prompts.
  * Added slash-command prompt suggestions with keyboard navigation and text or selection placeholders.
  * Added Usage preferences with spend, token, request, daily, and model breakdowns across selectable time ranges.
* **Enhancements**
  * Added automatic usage and estimated cost tracking for supported providers, including streamed responses.
  * Added default prompts to help users get started quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->